### PR TITLE
Update ransomware signatures

### DIFF
--- a/modules/signatures/ransomware_fileextensions.py
+++ b/modules/signatures/ransomware_fileextensions.py
@@ -97,7 +97,7 @@ class RansomwareExtensions(Signature):
             (".*\.ragnar_[A-Z0-9]{8}$", ["RagnarLocker"]),
             (".*\.key$", ["PwndLocker"]),
             (".*\.pwnd$", ["PwndLocker"]),
-            (".*\.ProLock$", ["ProLock"]),
+            (".*\.pr[o0]L[o0]ck$", ["ProLock"]),
             (".*\.abcd$", ["LockBit"]),
             (".*\.lockbit$", ["LockBit"]),
         ]

--- a/modules/signatures/ransomware_files.py
+++ b/modules/signatures/ransomware_files.py
@@ -145,7 +145,7 @@ class RansomwareFiles(Signature):
             (".*\\\\How_To_Decrypt_My_Files\.txt$", ["Ragnarok"]),
             (".*\\\\RGNR_[A-Z0-9]{8}\.txt$", ["RagnarLocker"]),
             (".*\\\\H0w_T0_Rec0very_Files\.txt$", ["PwndLocker"]),
-            (".*\\\\[HOW TO RECOVER FILES]\.txt$", ["ProLock"]),
+            (".*\\\\\[HOW TO RECOVER FILES\]\.txt$", ["ProLock"]),
 
         ]
 


### PR DESCRIPTION
ransomware_files.py: Escape square brackets. It will miss detection and is causing FPs in https://capesandbox.com/analysis/6218/, which is DNS tunneling DLL.

ransomware_fileextensions.py: Update to include variations of Prolock extentions.