### PR TITLE
correct syntax error in recon_fingerprint.py

### DIFF
--- a/modules/signatures/recon_fingerprint.py
+++ b/modules/signatures/recon_fingerprint.py
@@ -34,7 +34,7 @@ class Fingerprint(Signature):
         ]
 
         for indicator in indicators:
-            match = self.check_read_key(pattern=indicator, regex=True):
+            match = self.check_read_key(pattern=indicator, regex=True)
             if match:
                 self.data.append({"regkey": match})
                 return True


### PR DESCRIPTION
noticed a syntax error getting logged when running this sig.  Looks like a left over colon from the past change.