### PR TITLE
Change Commandline to ApplicationName in Equation Exploit

### DIFF
--- a/modules/signatures/office_exploit.py
+++ b/modules/signatures/office_exploit.py
@@ -37,7 +37,7 @@ class OfficeCVE201711882(Signature):
         pname = process["process_name"].lower()
         if pname == "eqnedt32.exe":
             if call["api"] == "CreateProcessInternalW":
-                buff = self.get_argument(call, "CommandLine")
+                buff = self.get_argument(call, "ApplicationName")
                 self.data.append({"created_process": buff })
 
     def on_complete(self):


### PR DESCRIPTION
Error in displaying created process due to it appearing in ApplicationName

![image](https://user-images.githubusercontent.com/2414517/89774880-997ee500-dafe-11ea-8ab7-cc6918190651.png)
