### PR TITLE
Tighten the Parallax yara due to FP

### DIFF
--- a/data/yara/CAPE/Parallax.yar
+++ b/data/yara/CAPE/Parallax.yar
@@ -19,5 +19,5 @@ strings:
 	$ = "[Ctrl +" ascii wide fullword
 
 condition:
-	3 of them
+	4 of them
 }


### PR DESCRIPTION
The yara matched on Remcos payload falsely. 
eg. https://www.capesandbox.com/analysis/110774
     https://www.capesandbox.com/analysis/110771