### PR TITLE
Remove type due to family misidentification

### DIFF
--- a/data/yara/CAPE/EnigmaStub.yar
+++ b/data/yara/CAPE/EnigmaStub.yar
@@ -5,7 +5,6 @@ meta:
 	author = "@bartblaze"
 	date = "2020-03"
 	tlp = "White"
-	cape_type = "Enigma Loader"
 
 strings:	
 	$ = "Enigma anti-emulators plugin - GetProcAddress" ascii wide


### PR DESCRIPTION
EnigmaStub is generic detection and does not associate as a specific/dedicated malware family. Examples:
https://capesandbox.com/analysis/151824/ (RedLine)
https://capesandbox.com/analysis/152239/ (NjRAT)
https://capesandbox.com/analysis/153215/ (Alfonoso)
https://capesandbox.com/analysis/144103/ (NjRAT)
https://capesandbox.com/analysis/144052/ (NjRAT)
https://capesandbox.com/analysis/138504/ (AsyncRAT)