### PR TITLE
Fix banker_zeus_mutex.py

### DIFF
--- a/modules/signatures/banker_zeus_mutex.py
+++ b/modules/signatures/banker_zeus_mutex.py
@@ -48,9 +48,4 @@ class ZeusMutexes(Signature):
                 self.data.append({"mutex": match})
                 return True
 
-        indicator = r"(Local|Global)\\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\}"
-        matches = self.check_mutex(pattern=indicator, regex=True, all=True)
-        if matches and len(matches) > 10:
-            return True
-
         return False


### PR DESCRIPTION
This ancient rule is causing frequent FPs, where `Windows Media Player\wmpnscfg.exe` is creating similar mutexes (e.g. ` Global\{1F871144-7189-4A4C-9D1B-1B36A4DAA74B}`)

![1](https://user-images.githubusercontent.com/921555/137460318-2991367e-f788-43b4-827f-e311065d91ba.png)
