### PR TITLE
update the signature move_file_on_reboot to ignore icon cache noise

### DIFF
--- a/modules/signatures/move_file_on_reboot.py
+++ b/modules/signatures/move_file_on_reboot.py
@@ -35,8 +35,14 @@ class move_file_on_reboot(Signature):
 
     def on_call(self, call, process):
         if call["api"] == "MoveFileWithProgressTransactedW" or call["api"] == "MoveFileWithProgressTransactedA" and self.get_raw_argument(call, "Flags") == MOVEFILE_DELAY_UNTIL_REBOOT:
-            self.data.append({"File Move on Reboot" : "Old: %s -> New: %s" % (self.get_argument(call, "ExistingFileName"), self.get_argument(call, "NewFileName")) })
-            self.match = True
+            # Filter out noise such as renaming C:\\Users\\Bubba\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_wide_alternate.db ...
+            # C:\\Users\\Bubba\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\icn30DD.tmp
+            if (
+                ( str( self.get_argument(call, "ExistingFileName") ).find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") == -1 ) and
+                ( str( self.get_argument(call, "NewFileName") ).find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\") == -1 )
+            ):
+                self.data.append({"File Move on Reboot" : "Old: %s -> New: %s" % (self.get_argument(call, "ExistingFileName"), self.get_argument(call, "NewFileName")) })
+                self.match = True
 
     def on_complete(self):
         return self.match

--- a/modules/signatures/move_file_on_reboot.py
+++ b/modules/signatures/move_file_on_reboot.py
@@ -37,11 +37,11 @@ class move_file_on_reboot(Signature):
         if call["api"] == "MoveFileWithProgressTransactedW" or call["api"] == "MoveFileWithProgressTransactedA" and self.get_raw_argument(call, "Flags") == MOVEFILE_DELAY_UNTIL_REBOOT:
             # Filter out noise such as renaming C:\\Users\\Bubba\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_wide_alternate.db ...
             # C:\\Users\\Bubba\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\icn30DD.tmp
-            if (
-                ( str( self.get_argument(call, "ExistingFileName") ).find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") == -1 ) and
-                ( str( self.get_argument(call, "NewFileName") ).find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\") == -1 )
-            ):
-                self.data.append({"File Move on Reboot" : "Old: %s -> New: %s" % (self.get_argument(call, "ExistingFileName"), self.get_argument(call, "NewFileName")) })
+            existingname = self.get_argument(call, "ExistingFileName")
+            newname = self.get_argument(call, "NewFileName")
+            if existingname and newname and not existingname.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") and \
+                not newname.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\"):
+                self.data.append({"File Move on Reboot" : "Old: %s -> New: %s" % (existingname, newname)})
                 self.match = True
 
     def on_complete(self):


### PR DESCRIPTION
If Windows decides to do any sort of icon cache maintenance during a run, it results in noise.

I've run into this randomly happening on Win10.