### PR TITLE
clean up uses_windows_utilities to avoid improper matching

### DIFF
--- a/modules/signatures/windows_utilities.py
+++ b/modules/signatures/windows_utilities.py
@@ -111,8 +111,7 @@ class UsesWindowsUtilities(Signature):
             lower = cmdline.lower()
             for utility in utilities:
                 if utility in lower and \
-                    '-' + utility not in lower and \
-                    utility + '=' not in lower:
+                    '-' + utility not in lower:
                         ret = True
                         self.data.append({"command" : cmdline})
 

--- a/modules/signatures/windows_utilities.py
+++ b/modules/signatures/windows_utilities.py
@@ -110,9 +110,11 @@ class UsesWindowsUtilities(Signature):
         for cmdline in cmdlines:
             lower = cmdline.lower()
             for utility in utilities:
-                if utility in lower:
-                    ret = True
-                    self.data.append({"command" : cmdline})
+                if utility in lower and \
+                    '-' + utility not in lower and \
+                    utility + '=' not in lower:
+                        ret = True
+                        self.data.append({"command" : cmdline})
 
         return ret
 


### PR DESCRIPTION
This is to help avoid matching on something like "\"C:\\Program Files (x86)\\Adobe\\Reader 11.0\\Reader\\AcroRd32.exe\" --channel=1824.1.41778424 --type=renderer  \"C:\\Users\\Fifi\\AppData\\Local\\Temp\\freebsd handbook.pdf\"", which it currently does. Currently that sig will trigger as type is present in the string instead of being used as a command. To avoid this, make sure it is not a switch via checking if it starts with a -.

Was originally thinking of a second check for = at the end of it as well, but a few of these have spaces at the end, meaning it is not doable.
