### PR TITLE
ransomware_file_modifications fix for file_modifications to avoid triggering on win10 flushing the icon cache

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -45,6 +45,9 @@ class RansomwareFileModifications(Signature):
             return None
         origfile = self.get_argument(call, "ExistingFileName")
         newfile = self.get_argument(call, "NewFileName")
+        if origfile.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") and \
+            newfile.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\"):
+                return None
         self.movefilecount += 1
         if origfile != newfile and "@" not in newfile:
             origextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", origfile)


### PR DESCRIPTION
Not sure what exactly triggers it, but Win10 will every so often decide to flush the icon cache and when this happens this is improperly triggered.

To avoid this if this condition is matched, the count is not incremented.

```
if origfile.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") and \
    newfile.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\"):
```
