### PR TITLE
add a additional disk reg that may be checked for when checking if it is in a VM

### DIFF
--- a/modules/signatures/antivm_generic_diskreg.py
+++ b/modules/signatures/antivm_generic_diskreg.py
@@ -30,6 +30,7 @@ class AntiVMDiskReg(Signature):
         indicators = [
             ".*\\\\SYSTEM\\\\(CurrentControlSet|ControlSet001)\\\\Enum\\\\IDE$",
             ".*\\\\SYSTEM\\\\(CurrentControlSet|ControlSet001)\\\\Services\\\\Disk\\\\Enum\\\\.*",
+            ".*\\\\HARDWARE\\\\DEVICEMAP\\\\Scsi\\\\Scsi\ Port\ 0\\\\Scsi\ Bus\ 0\\\\Target\ Id\ 0\\\\Logical\ Unit\ Id\ 0$",
         ]
         for indicator in indicators:
             if self.check_key(pattern=indicator, regex=True):


### PR DESCRIPTION
"HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0" has various items under it that are likely to be checked if checking for if it is running in a VM. For example the QEMU disk serial if not specified is very predictable.