### PR TITLE
Create signature for \x00 wiper malware

### DIFF
--- a/modules/signatures/wiper.py
+++ b/modules/signatures/wiper.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2022 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+
+class WiperZeroedBytes(Signature):
+    name = "wiper_zeroedbytes"
+    description = "Overwrites multiple files with zero bytes (hex 00) indicative of a wiper"
+    severity = 3
+    categories = ["wiper"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+    match = True
+    ttp = ["T1561"]
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)      
+        self.wipecount = 0
+        self.lastfile = ""
+
+    filter_apinames = set(["NtWriteFile"])
+    def on_call(self, call, process):
+        filepath = self.get_raw_argument(call, "HandleName")
+        if filepath != self.lastfile:
+            buff = self.get_raw_argument(call, "Buffer").lower()
+            regex = re.compile('^[\\x00\.]+$')
+            if len(buff) > 30 and regex.match(buff):
+                self.lastfile = filepath
+                self.wipecount += 1
+
+    def on_complete(self):
+        ret = False             
+        if self.wipecount > 10:
+            self.data.append({"number of files wiped": "%s" %(self.wipecount)})                     
+            ret = True
+                
+        return ret


### PR DESCRIPTION
Add signature for when potential wiper overwrites multiple files with \x00. This can be seen in CaddyWiper which was detected being used in Ukraine 14/3/2022. 

There are other ways to overwrite files and random bytes would be another but I do not have a detection method for that technique yet although I am thinking along the lines of overwriting multiple files it did not create but this would be a lower severity signature due to it being also indicative of installers.

CaddyWiper
![image](https://user-images.githubusercontent.com/2414517/160250769-d73a5a61-0ab5-43c7-9385-656017959e2b.png)
