### PR TITLE
To use filter_apinames, signature must be evented

### DIFF
--- a/modules/signatures/rat_karagany.py
+++ b/modules/signatures/rat_karagany.py
@@ -29,6 +29,7 @@ class KaraganyEventObjects(Signature):
     families = ["Karagany", "xFrost"]
     authors = ["ditekshen"]
     minimum = "0.5"
+    evented = True
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)


### PR DESCRIPTION
This is the only use for the `filter_apinames` field in logic 
https://github.com/kevoreilly/CAPEv2/blob/5b3ceea578e0d90cbd61886b443a37cb13160c64/lib/cuckoo/core/plugins.py#L500

And to get to that point, the signature must be `evented`.