### PR TITLE
Family should be families

### DIFF
--- a/modules/signatures/infostealer_apocalypse.py
+++ b/modules/signatures/infostealer_apocalypse.py
@@ -21,7 +21,7 @@ class ApocalypseStealerFileBehavior(Signature):
     description = "Apocalypse infostealer file modification behavior detected"
     severity = 3
     categories = ["infostealer"]
-    family = ["Apocalypse"]
+    families = ["Apocalypse"]
     authors = ["ditekshen"]
     minimum = "2.0"
     evented = True

--- a/modules/signatures/rat_lodarat.py
+++ b/modules/signatures/rat_lodarat.py
@@ -21,7 +21,7 @@ class LodaRATFileBehavior(Signature):
     description = "LodaRAT file modification behavior detected"
     severity = 3
     categories = ["RAT"]
-    family = ["LodaRAT"]
+    families = ["LodaRAT"]
     authors = ["ditekshen"]
     minimum = "2.0"
     evented = True

--- a/modules/signatures/trojan_ursnif.py
+++ b/modules/signatures/trojan_ursnif.py
@@ -23,7 +23,7 @@ class UrsnifBehavior(Signature):
     description = "Ursnif Trojan behavior detected"
     severity = 3
     categories = ["Trojan"]
-    family = ["Ursnif"]
+    families = ["Ursnif"]
     authors = ["ditekshen"]
     minimum = "2.0"
     ttp = ["S0386"]


### PR DESCRIPTION
For consistency https://github.com/kevoreilly/CAPEv2/blob/6de60f504e87fd8a59a182a3f3cdad8b604adddd/lib/cuckoo/common/abstracts.py#L723

Only `families` is used https://github.com/kevoreilly/CAPEv2/blob/5b3ceea578e0d90cbd61886b443a37cb13160c64/lib/cuckoo/core/plugins.py#L604