### PR TITLE
ttps should be ttp

### DIFF
--- a/modules/signatures/alphacrypt_apis.py
+++ b/modules/signatures/alphacrypt_apis.py
@@ -31,7 +31,7 @@ class Alphacrypt_APIs(Signature):
     authors = ["KillerInstinct"]
     minimum = "1.2"
     evented = True
-    ttps = ["T1486"]
+    ttp = ["T1486"]
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)

--- a/modules/signatures/cape_browser_mitb.py
+++ b/modules/signatures/cape_browser_mitb.py
@@ -24,7 +24,7 @@ class CAPEExtractedContent(Signature):
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
-    ttps = ["T1185"]
+    ttp = ["T1185"]
 
     def run(self):
         browsertargets = [


### PR DESCRIPTION
For consistency's sake...

Of 676 signatures, 283 have the parameter `ttp` and two have the parameter `ttps`. Nomenclature-wise I think the attribute should be `ttps`, but fixing two signatures is a lot easier than fixing 283.