### PR TITLE
Updating categories to more common ones

### DIFF
--- a/modules/signatures/antiav_bypass.py
+++ b/modules/signatures/antiav_bypass.py
@@ -22,7 +22,7 @@ class ModifiesAttachmentManager(Signature):
         "Attempts to modify the Microsoft attachment manager possibly to bypass security checks on mail and Internet saved files"
     )
     severity = 3
-    categories = ["antiav", "bypass"]
+    categories = ["anti-av", "bypass"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     references = ["https://support.microsoft.com/en-us/help/883260/information-about-the-attachment-manager-in-microsoft-windows"]

--- a/modules/signatures/antisandbox_sboxie_mutex.py
+++ b/modules/signatures/antisandbox_sboxie_mutex.py
@@ -20,7 +20,7 @@ class AntisandboxSboxieMutex(Signature):
     name = "antisandbox_sboxie_mutex"
     description = "Detects Sandboxie using a known mutex"
     severity = 3
-    categories = ["antisandbox"]
+    categories = ["anti-sandbox"]
     authors = ["KillerInstinct"]
     minimum = "1.2"
     ttps = ["T1063"]

--- a/modules/signatures/antisandbox_sboxie_objects.py
+++ b/modules/signatures/antisandbox_sboxie_objects.py
@@ -20,7 +20,7 @@ class AntiSandboxSboxieObjects(Signature):
     name = "antisandbox_sboxie_objects"
     description = "The sample enumerated a known Sandboxie device object."
     severity = 3
-    categories = ["antisandbox"]
+    categories = ["anti-sandbox"]
     authors = ["KillerInstinct"]
     minimum = "1.0"
     evented = True

--- a/modules/signatures/antivm_dirobjects.py
+++ b/modules/signatures/antivm_dirobjects.py
@@ -21,7 +21,7 @@ class AntiVMDirectoryObjects(Signature):
     description = "The sample enumerated directory objects, possibly probing for Virtual Machine objects."
     severity = 2
     confidence = 80
-    categories = ["antivm"]
+    categories = ["anti-vm"]
     authors = ["KillerInstinct"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/antivm_vmware_mutexes.py
+++ b/modules/signatures/antivm_vmware_mutexes.py
@@ -20,7 +20,7 @@ class VMwareDetectMutexes(Signature):
     name = "antivm_vmware_mutexes"
     description = "Attempts to detect VMware using known mutexes"
     severity = 3
-    categories = ["antivm"]
+    categories = ["anti-vm"]
     authors = ["KillerInstinct"]
     minimum = "0.5"
     mbcs = ["B0009"]

--- a/modules/signatures/banker_cridex.py
+++ b/modules/signatures/banker_cridex.py
@@ -21,7 +21,7 @@ class Cridex(Signature):
     description = "Cridex banking trojan"
     severity = 3
     alert = True
-    categories = ["banker", "Trojan"]
+    categories = ["banker", "trojan"]
     families = ["Cridex"]
     authors = ["Robby Zeitfuchs", "@robbyFux"]
     minimum = "0.5"

--- a/modules/signatures/banker_geodo.py
+++ b/modules/signatures/banker_geodo.py
@@ -9,7 +9,7 @@ class Geodo(Signature):
     name = "geodo_banking_trojan"
     description = "Geodo banker Trojan"
     severity = 3
-    categories = ["banker", "Trojan"]
+    categories = ["banker", "trojan"]
     families = ["Geodo", "Emotet"]
     authors = ["Optiv"]
     minimum = "1.2"

--- a/modules/signatures/clamav.py
+++ b/modules/signatures/clamav.py
@@ -26,7 +26,7 @@ class ClamAV(Signature):
     description = "Clamav Hits in Target/Dropped/SuriExtracted"
     severity = 3
     weight = 0
-    categories = ["clamav"]
+    categories = ["antivirus"]
     authors = ["Will Metcalf"]
     minimum = "1.2"
 

--- a/modules/signatures/cmdline_anomaly.py
+++ b/modules/signatures/cmdline_anomaly.py
@@ -25,7 +25,7 @@ class CmdlineObfuscation(Signature):
     name = "cmdline_obfuscation"
     description = "Appears to use command line obfuscation"
     severity = 3
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -78,7 +78,7 @@ class CmdlineSwitches(Signature):
     name = "cmdline_switches"
     description = "Executed a command line with /V argument which modifies variable behaviour and whitespace allowing for increased obfuscation options"
     severity = 2
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -98,7 +98,7 @@ class CmdlineTerminate(Signature):
     name = "cmdline_terminate"
     description = "Executed a command line with /C or /R argument to terminate command shell on completion which can be used to hide execution"
     severity = 1
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -119,7 +119,7 @@ class LongCommandline(Signature):
     description = "Executed a very long command line or script command which may be indicative of chained commands or obfuscation"
     severity = 2
     confidence = 50
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -151,7 +151,7 @@ class CommandLineHTTPLink(Signature):
     name = "cmdline_http_link"
     description = "A HTTP/S link was seen in a script or command line"
     severity = 2
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -184,7 +184,7 @@ class CommandLineReversedHTTPLink(Signature):
     name = "cmdline_reversed_http_link"
     description = "A reversed HTTP/S link was seen in a script or command line"
     severity = 3
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -217,7 +217,7 @@ class PowershellRenamedCommandLine(Signature):
     name = "powershell_renamed_commandline"
     description = "PowerShell has likely been renamed in a command line"
     severity = 3
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -238,7 +238,7 @@ class CommandLineLongString(Signature):
     name = "commandline_long_string"
     description = "A script or command line contains a long continuous string indicative of obfuscation"
     severity = 3
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -271,7 +271,7 @@ class CommandLineForFilesWildCard(Signature):
     name = "commandline_forfiles_wildcard"
     description = "Possible use of forfiles utility with wildcard to potentially launch a utility"
     severity = 3
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/credential_dumping.py
+++ b/modules/signatures/credential_dumping.py
@@ -20,7 +20,7 @@ class LsassCredentialDumping(Signature):
     name = "lsass_credential_dumping"
     description = "Requests access to read memory contents of lsass.exe potentially indicative of credential dumping"
     severity = 3
-    categories = ["persistence", "lateral_movement", "credential_dumping"]
+    categories = ["persistence", "lateral", "credential_dumping"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -78,7 +78,7 @@ class RegistryCredentialDumping(Signature):
     name = "registry_credential_dumping"
     description = "Dumps credentials from the registry using the Windows reg utility"
     severity = 3
-    categories = ["persistence", "lateral_movement", "credential_dumping"]
+    categories = ["persistence", "lateral", "credential_dumping"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -100,7 +100,7 @@ class RegistryCredentialStoreAccess(Signature):
     name = "registry_credential_store_access"
     description = "Accessed credential storage registry keys"
     severity = 3
-    categories = ["persistence", "lateral_movement", "credential_dumping"]
+    categories = ["persistence", "lateral", "credential_dumping"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/cryptopools.py
+++ b/modules/signatures/cryptopools.py
@@ -5,7 +5,7 @@ class MINERS(Signature):
     name = "cryptopool_domains"
     description = "Connects to crypto currency mining pool"
     severity = 1
-    categories = ["miners"]
+    categories = ["cryptomining"]
     authors = ["doomedraven", "bartblaze"]
     minimum = "1.2"
     ttps = ["T1496"]

--- a/modules/signatures/disables_windefender.py
+++ b/modules/signatures/disables_windefender.py
@@ -11,7 +11,7 @@ class DisablesWindowsDefender(Signature):
     name = "disables_windows_defender"
     description = "Attempts to disable Windows Defender"
     severity = 3
-    categories = ["antiav"]
+    categories = ["anti-av"]
     authors = ["Brad Spengler", "Kevin Ross", "ditekshen"]
     minimum = "1.2"
     ttps = ["T1089"]
@@ -78,7 +78,7 @@ class WindowsDefenderPowerShell(Signature):
     name = "windows_defender_powershell"
     description = "Attempts to modify Windows Defender using PowerShell"
     severity = 3
-    categories = ["antiav"]
+    categories = ["anti-av"]
     authors = ["Kevin Ross"]
     minimum = "1.2"
     ttps = ["T1089"]
@@ -102,7 +102,7 @@ class RemovesWindowsDefenderContextMenu(Signature):
     name = "removes_windows_defender_contextmenu"
     description = "Attempts to remove Windows Defender from context menu"
     severity = 3
-    categories = ["antiav"]
+    categories = ["anti-av"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1089"]
@@ -134,7 +134,7 @@ class DisablesWindowsDefenderLogging(Signature):
     name = "disables_windows_defender_logging"
     description = "Attempts to disable Windows Defender logging"
     severity = 3
-    categories = ["antiav"]
+    categories = ["anti-av"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1089"]

--- a/modules/signatures/downloader_guloader.py
+++ b/modules/signatures/downloader_guloader.py
@@ -25,7 +25,7 @@ class GuLoaderAPIs(Signature):
     name = "guloader_apis"
     description = "Exhibits behavior characteristics of GuLoader"
     severity = 3
-    categories = ["downloder", "injection", "shellcode"]
+    categories = ["downloader", "injection", "shellcode"]
     families = ["GuLoader", "CloudEye"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/encrypted_ioc.py
+++ b/modules/signatures/encrypted_ioc.py
@@ -15,7 +15,7 @@ class EncryptedIOC(Signature):
     description = "At least one IP Address, Domain, or File Name was found in a crypto call"
     severity = 2
     weight = 0
-    categories = ["crypto"]
+    categories = ["encryption"]
     authors = ["KillerInstinct"]
     minimum = "1.2"
     evented = True

--- a/modules/signatures/excel4_macro_urls.py
+++ b/modules/signatures/excel4_macro_urls.py
@@ -21,7 +21,7 @@ class Excel4MacroUrls(Signature):
     description = "URLs from Excel 4.0 XLM Macro(s)"
     weight = 3
     severity = 3
-    categories = ["macros", "office"]
+    categories = ["macro", "office"]
     authors = ["doomedraven"]
     minimum = "2.0"
     evented = False

--- a/modules/signatures/exploit_spooler.py
+++ b/modules/signatures/exploit_spooler.py
@@ -25,7 +25,7 @@ class SpoolerSvcStart(Signature):
     name = "spooler_svc_start"
     description = "Executes the printer spooler process"
     severity = 2
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["bartblaze"]
     minimum = "1.3"
 

--- a/modules/signatures/exploitation_framework_koadic.py
+++ b/modules/signatures/exploitation_framework_koadic.py
@@ -25,7 +25,7 @@ class KoadicAPIs(Signature):
     name = "koadic_apis"
     description = "Exhibits behavior characteristics of Koadic post-exploitation framework"
     severity = 3
-    categories = ["exploitation"]
+    categories = ["exploit"]
     families = ["Koadic"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -84,7 +84,7 @@ class KoadicNetworkActivity(Signature):
     name = "koadic_network_activity"
     description = "Establishes network traffic characteristics of Koadic post-exploitation framework"
     severity = 3
-    categories = ["exploitation"]
+    categories = ["exploit"]
     families = ["Koadic"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/infostealer_arkei.py
+++ b/modules/signatures/infostealer_arkei.py
@@ -20,7 +20,7 @@ class ArkeiFiles(Signature):
     name = "arkei_files"
     description = "Creates Arkei infostealer directories and/or files"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Arkei"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/infostealer_raccoon.py
+++ b/modules/signatures/infostealer_raccoon.py
@@ -82,7 +82,7 @@ class raccoon(Signature):
     description = "Detects Raccoon Behavior"
     weight = 3
     severity = 3
-    categories = ["Infostealer"]
+    categories = ["infostealer"]
     families = ["Raccoon"]
     authors = ["@NaxoneZ"]
     minimum = "1.2"

--- a/modules/signatures/infostealer_screenshot.py
+++ b/modules/signatures/infostealer_screenshot.py
@@ -20,7 +20,7 @@ class CapturesScreenshot(Signature):
     name = "captures_screenshot"
     description = "Captures Screenshot"
     severity = 3
-    categories = ["infostealer", "RAT"]
+    categories = ["infostealer", "rat"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1113"]

--- a/modules/signatures/infostealer_vidar.py
+++ b/modules/signatures/infostealer_vidar.py
@@ -38,7 +38,7 @@ class vidar(Signature):
     description = "Detects Vidar Behavior"
     weight = 3
     severity = 3
-    categories = ["Infostealer"]
+    categories = ["infostealer"]
     families = ["Vidar"]
     authors = ["@NaxoneZ"]
     minimum = "1.2"

--- a/modules/signatures/mimikatz_modules.py
+++ b/modules/signatures/mimikatz_modules.py
@@ -20,7 +20,7 @@ class MimikatzModules(Signature):
     name = "mimikatz_modules"
     description = "Executed a potential Mimikatz module"
     severity = 3
-    categories = ["lateral_movement", "credential_dumping"]
+    categories = ["lateral", "credential_dumping"]
     authors = ["bartblaze"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/miner_quilminer.py
+++ b/modules/signatures/miner_quilminer.py
@@ -20,7 +20,7 @@ class QuilMinerNetworkBehavior(Signature):
     name = "quilclipper_behavior"
     description = "QuilMiner network artifacts detected"
     severity = 3
-    categories = ["miner"]
+    categories = ["cryptomining"]
     families = ["QuilMiner"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/network_cnc_encrypted.py
+++ b/modules/signatures/network_cnc_encrypted.py
@@ -502,7 +502,7 @@ class NetworkCnCSMTPSExfil(Signature):
     name = "network_cnc_smtps_exfil"
     description = "keylogger detected exfiltrating data via encrypted SMTPS connection"
     severity = 3
-    categories = ["network", "encryption", "exfiltration", "infostealer", "RAT"]
+    categories = ["network", "encryption", "exfiltration", "infostealer", "rat"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1020", "T1032", "T1041"]

--- a/modules/signatures/office_dll_loading.py
+++ b/modules/signatures/office_dll_loading.py
@@ -76,7 +76,7 @@ class OfficeVBLLoad(Signature):
     name = "office_vb_load"
     description = "Office loads VB DLLs, indicative of Office Macros"
     severity = 2
-    categories = ["office", "macros"]
+    categories = ["office", "macro"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1137", "T1204"]
@@ -107,7 +107,7 @@ class OfficeWMILoad(Signature):
     name = "office_wmi_load"
     description = "Office loads WMI DLLs, indicative of Office Macros executing WMI commands"
     severity = 2
-    categories = ["office", "macros"]
+    categories = ["office", "macro"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1137", "T1204"]
@@ -133,7 +133,7 @@ class OfficeCOMLoad(Signature):
     name = "office_com_load"
     description = "Office loads COM DLLs, indicative of Office Macros spawning CMD process for execution"
     severity = 2
-    categories = ["office", "macros"]
+    categories = ["office", "macro"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1137", "T1204"]
@@ -162,7 +162,7 @@ class OfficeDotNetLoad(Signature):
     name = "office_dotnet_load"
     description = "Office loads .NET assembly or DLL, indicative of suspicious Office Macros activities"
     severity = 2
-    categories = ["office", "macros"]
+    categories = ["office", "macro"]
     authors = ["ditekshen"]
     minimum = "1.3"
     ttps = ["T1137", "T1204"]

--- a/modules/signatures/powershell_command.py
+++ b/modules/signatures/powershell_command.py
@@ -30,7 +30,7 @@ class PowershellCommandSuspicious(Signature):
     description = "Attempts to execute suspicious powershell command arguments"
     severity = 3
     confidence = 70
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross", "Optiv"]
     minimum = "1.3"
     evented = True
@@ -127,7 +127,7 @@ class PowershellRenamed(Signature):
     description = "Powershell arguments were seen on a command line but powershell.exe was not called. Likely indictive of renamed/obfuscated powershell.exe or defining arguments in variables for later use"
     severity = 3
     confidence = 70
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross", "Optiv"]
     minimum = "1.3"
     evented = True
@@ -213,7 +213,7 @@ class PowershellReversed(Signature):
     description = "Possible reversed powershell command arguments detected"
     severity = 3
     confidence = 70
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross", "Optiv"]
     minimum = "1.3"
     evented = True
@@ -276,7 +276,7 @@ class PowershellVariableObfuscation(Signature):
     description = "A powershell command using multiple variables was executed possibly indicative of obfuscation"
     severity = 3
     confidence = 50
-    categories = ["commands", "obuscation"]
+    categories = ["command", "obuscation"]
     authors = ["Kevin Ross", "Optiv"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/ransomware_sodinokibi.py
+++ b/modules/signatures/ransomware_sodinokibi.py
@@ -13,7 +13,7 @@ class sodinokibi(Signature):
     description = "Detects Agent Sodinokibi Behavior"
     weight = 3
     severity = 3
-    categories = ["Ransomware"]
+    categories = ["ransomware"]
     families = ["Sodinokibi"]
     authors = ["@NaxoneZ"]
     minimum = "1.2"

--- a/modules/signatures/rat_blacknet.py
+++ b/modules/signatures/rat_blacknet.py
@@ -20,7 +20,7 @@ class BlackNETMutexes(Signature):
     name = "blacknet_mutexes"
     description = "BlackNET RAT mutex detected"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["BlackNET"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_blackremote.py
+++ b/modules/signatures/rat_blackremote.py
@@ -25,7 +25,7 @@ class BlackRATMutexes(Signature):
     name = "blackrat_mutexes"
     description = "Creates BlackRemote/BlackRAT RAT mutexes"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["BlackRAT", "BlackRemote"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -48,7 +48,7 @@ class BlackRATRegistryKeys(Signature):
     name = "blackrat_registry_keys"
     description = "Creates or accesses BlackRemote/BlackRAT RAT registry keys"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["BlackRAT", "BlackRemote"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -91,7 +91,7 @@ class BlackRATNetworkActivity(Signature):
     name = "blackrat_network_activity"
     description = "Establishes BlackRemote/BlackRAT RAT network activity"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["BlackRAT", "BlackRemote"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -118,7 +118,7 @@ class BlackRATAPIs(Signature):
     name = "blackrat_apis"
     description = "Exhibits behavior characteristics of BlackRemote/BlackRAT RAT"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["BlackRAT", "BlackRemote"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_dcrat.py
+++ b/modules/signatures/rat_dcrat.py
@@ -25,7 +25,7 @@ class DCRatFiles(Signature):
     name = "dcrat_files"
     description = "Creates DCRat RAT directories and/or files"
     severity = 3
-    categories = ["infostealer", "keylogger", "RAT"]
+    categories = ["infostealer", "keylogger", "rat"]
     families = ["DCRat"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -49,7 +49,7 @@ class DCRatMutex(Signature):
     name = "dcrat_mutexes"
     description = "Creates DCRat RAT mutexes"
     severity = 3
-    categories = ["infostealer", "keylogger", "RAT"]
+    categories = ["infostealer", "keylogger", "rat"]
     families = ["DCRat"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -84,7 +84,7 @@ class DCRatAPIs(Signature):
     description = "Exhibits behavior characteristics of DCRat RAT"
     severity = 3
     weight = 3
-    categories = ["infostealer", "keylogger", "RAT"]
+    categories = ["infostealer", "keylogger", "rat"]
     families = ["DCRat"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_karagany.py
+++ b/modules/signatures/rat_karagany.py
@@ -25,7 +25,7 @@ class KaraganyEventObjects(Signature):
     name = "karagany_system_event_objects"
     description = "Creates system event objects associated with Karagany/xFrost RAT"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Karagany", "xFrost"]
     authors = ["ditekshen"]
     minimum = "0.5"
@@ -58,7 +58,7 @@ class KaraganyFiles(Signature):
     name = "karagany_files"
     description = "Creates files/directories associated with Karagany/xFrost RAT"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Karagany", "xFrost"]
     authors = ["ditekshen"]
     minimum = "0.5"

--- a/modules/signatures/rat_limerat.py
+++ b/modules/signatures/rat_limerat.py
@@ -20,7 +20,7 @@ class LimeRATMutexes(Signature):
     name = "limerat_mutexes"
     description = "Creates known LimeRAT RAT mutexes"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["LimeRAT"]
     authors = ["ditekshen"]
     minimum = "0.5"
@@ -44,7 +44,7 @@ class LimeRATRegkeys(Signature):
     name = "limerat_regkeys"
     description = "Creates known LimeRAT RAT registry keys"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["LimeRAT"]
     authors = ["ditekshen"]
     minimum = "0.5"

--- a/modules/signatures/rat_lodarat.py
+++ b/modules/signatures/rat_lodarat.py
@@ -20,7 +20,7 @@ class LodaRATFileBehavior(Signature):
     name = "lodarat_file_behavior"
     description = "LodaRAT file modification behavior detected"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["LodaRAT"]
     authors = ["ditekshen"]
     minimum = "2.0"

--- a/modules/signatures/rat_netwire.py
+++ b/modules/signatures/rat_netwire.py
@@ -11,7 +11,7 @@ class netwire(Signature):
     description = "Detects NetWire Behavior"
     weight = 3
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["NetWire"]
     authors = ["@NaxoneZ"]
     minimum = "1.2"

--- a/modules/signatures/rat_oblique.py
+++ b/modules/signatures/rat_oblique.py
@@ -20,7 +20,7 @@ class ObliquekRATMutexes(Signature):
     name = "obliquerat_mutexes"
     description = "Creates ObliqueRAT RAT mutexes"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["ObliqueRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -43,7 +43,7 @@ class ObliquekRATFiles(Signature):
     name = "obliquerat_files"
     description = "Creates ObliqueRAT RAT directories and/or files"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["ObliqueRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -68,7 +68,7 @@ class ObliquekRATNetworkActivity(Signature):
     name = "obliquerat_network_activity"
     description = "Establishes ObliqueRAT RAT network activity"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["ObliqueRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_orcus.py
+++ b/modules/signatures/rat_orcus.py
@@ -6,7 +6,7 @@ class OrcusRAT(Signature):
     description = "Detects OrcusRAT Behavior"
     weight = 3
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["OrcusRAT"]
     authors = ["@NaxoneZ"]
     minimum = "1.2"

--- a/modules/signatures/rat_parallax_mutex.py
+++ b/modules/signatures/rat_parallax_mutex.py
@@ -20,7 +20,7 @@ class ParallaxMutexes(Signature):
     name = "parallax_mutexes"
     description = "Creates a known Parallax RAT mutex"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Parallax"]
     authors = ["bartblaze"]
     minimum = "0.5"

--- a/modules/signatures/rat_trochilus.py
+++ b/modules/signatures/rat_trochilus.py
@@ -20,7 +20,7 @@ class TrochilusRATAPIs(Signature):
     name = "trochilusrat_APIs"
     description = "TrochilusRAT behavior detected"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["TrochilusRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_venom.py
+++ b/modules/signatures/rat_venom.py
@@ -20,7 +20,7 @@ class VenomRAT(Signature):
     name = "venomrat_mutexes"
     description = "Creates VenomRAT mutexes"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["VenomRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_warzone.py
+++ b/modules/signatures/rat_warzone.py
@@ -20,7 +20,7 @@ class WarzoneRATRegkeys(Signature):
     name = "warzonerat_regkeys"
     description = "Creates WarzoneRAT registry keys"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["WarzoneRAT", "AveMaria"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -44,7 +44,7 @@ class WarzoneRATFiles(Signature):
     name = "warzonerat_files"
     description = "Accesses or creates Warzone RAT directories and/or files"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["WarzoneRAT", "AveMaria"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/rat_xpert.py
+++ b/modules/signatures/rat_xpert.py
@@ -20,7 +20,7 @@ class XpertRATMutexes(Signature):
     name = "xpertrat_mutexes"
     description = "XpertRAT RAT mutexes detected"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["XpertRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -49,7 +49,7 @@ class XpertRATFiles(Signature):
     name = "xpertrat_files"
     description = "XpertRAT RAT files detected"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["XpertRAT"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/remcos.py
+++ b/modules/signatures/remcos.py
@@ -20,7 +20,7 @@ class RemcosFiles(Signature):
     name = "remcos_files"
     description = "Creates known Remcos directories and/or files"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Remcos"]
     authors = ["ditekshen"]
     minimum = "0.5"
@@ -44,7 +44,7 @@ class RemcosMutexes(Signature):
     name = "remcos_mutexes"
     description = "Creates known Remcos mutexes"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Remcos"]
     authors = ["ditekshen"]
     minimum = "0.5"
@@ -70,7 +70,7 @@ class RemcosRegkeys(Signature):
     name = "remcos_regkeys"
     description = "Creates known Remcos registry keys"
     severity = 3
-    categories = ["RAT"]
+    categories = ["rat"]
     families = ["Remcos"]
     authors = ["ditekshen"]
     minimum = "0.5"

--- a/modules/signatures/sysinternals.py
+++ b/modules/signatures/sysinternals.py
@@ -20,7 +20,7 @@ class sysinternals_tools(Signature):
     name = "sysinternals_tools"
     description = "Executed a sysinternals tool"
     severity = 2
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -43,7 +43,7 @@ class sysinternals_psexec(Signature):
     name = "sysinternals_psexec"
     description = "PSExec was executed"
     severity = 3
-    categories = ["commands", "lateral"]
+    categories = ["command", "lateral"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/territorial_disputes_sigs.py
+++ b/modules/signatures/territorial_disputes_sigs.py
@@ -20,7 +20,7 @@ class TerritorialDisputeSIGs(Signature):
     name = "territorial_disputes_sigs"
     description = "Creates an indicator observed in Territorial Disputes report"
     severity = 1
-    categories = ["general"]
+    categories = ["generic"]
     authors = ["ditekshen"]
     minimum = "1.3"
     evented = True

--- a/modules/signatures/trojan_ursnif.py
+++ b/modules/signatures/trojan_ursnif.py
@@ -22,7 +22,7 @@ class UrsnifBehavior(Signature):
     name = "ursnif_behavior"
     description = "Ursnif Trojan behavior detected"
     severity = 3
-    categories = ["Trojan"]
+    categories = ["trojan"]
     families = ["Ursnif"]
     authors = ["ditekshen"]
     minimum = "2.0"

--- a/modules/signatures/webshell.py
+++ b/modules/signatures/webshell.py
@@ -20,7 +20,7 @@ class WebShellProcesses(Signature):
     name = "web_shell_processes"
     description = "Creates or executes process commonly used for running web applications, used by web shells"
     severity = 2
-    categories = ["commands", "evasion"]
+    categories = ["command", "evasion"]
     authors = ["bartblaze"]
     minimum = "1.3"
     ttps = ["T1505"]
@@ -53,7 +53,7 @@ class WebShellFiles(Signature):
     name = "web_shell_files"
     description = "Writes to the inetpub or inetsrv default path, typically seen in web shells"
     severity = 2
-    categories = ["Webshell"]
+    categories = ["webshell"]
     authors = ["bartblaze"]
     minimum = "0.5"
     ttps = ["T1505"]
@@ -74,7 +74,7 @@ class OWAWebShellFiles(Signature):
     name = "owa_web_shell_files"
     description = "Writes to the Exchange OWA folder, typically seen in Outlook Web Access web shells"
     severity = 2
-    categories = ["Webshell"]
+    categories = ["webshell"]
     authors = ["bartblaze"]
     minimum = "0.5"
     ttps = ["T1505"]

--- a/modules/signatures/windows_utilities.py
+++ b/modules/signatures/windows_utilities.py
@@ -10,7 +10,7 @@ class UsesWindowsUtilitiesScheduler(Signature):
     description = "Uses Windows utilities for basic functionality"
     severity = 2
     confidence = 80
-    categories = ["commands", "lateral"]
+    categories = ["command", "lateral"]
     authors = ["Cuckoo Technologies", "Kevin Ross"]
     minimum = "1.3"
     ttps = ["T1053"]
@@ -41,7 +41,7 @@ class UsesWindowsUtilities(Signature):
     description = "Uses Windows utilities for basic functionality"
     severity = 2
     confidence = 80
-    categories = ["commands", "lateral"]
+    categories = ["command", "lateral"]
     authors = ["Cuckoo Technologies", "Kevin Ross"]
     minimum = "1.3"
 
@@ -121,7 +121,7 @@ class SuspiciousCommandTools(Signature):
     description = "Uses suspicious command line tools or Windows utilities"
     severity = 3
     confidence = 80
-    categories = ["commands", "lateral"]
+    categories = ["command", "lateral"]
     authors = ["Cuckoo Technologies", "Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -196,7 +196,7 @@ class ScriptToolExecuted(Signature):
     description = "A scripting utility was executed"
     severity = 2
     confidence = 80
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -225,7 +225,7 @@ class SuspiciousPingUse(Signature):
     description = "A ping command was executed with the -n argument possibly to delay analysis"
     severity = 2
     confidence = 100
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -248,7 +248,7 @@ class WMICCommandSuspicious(Signature):
     description = "Suspicious wmic.exe use was detected"
     severity = 3
     confidence = 80
-    categories = ["commands", "wmi"]
+    categories = ["command", "wmi"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -297,7 +297,7 @@ class AltersWindowsUtility(Signature):
     description = "Attempts to move, copy or rename a command line or scripting utility likely for evasion"
     severity = 3
     confidence = 100
-    categories = ["commands", "stealth", "evasion"]
+    categories = ["command", "stealth", "evasion"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -349,7 +349,7 @@ class SuspiciousCertutilUse(Signature):
     description = "Suspicious use of certutil was detected"
     severity = 3
     confidence = 100
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -414,7 +414,7 @@ class DotNETCSCBuild(Signature):
     description = "Uses csc.exe C# compiler to build and execute code"
     severity = 3
     confidence = 20
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
@@ -439,7 +439,7 @@ class UsesWindowsUtilitiesCipher(Signature):
     name = "uses_windows_utilities_cipher"
     description = "Uses cipher.exe to wipe the free space, as seen in some ransomware"
     severity = 3
-    categories = ["commands", "impact"]
+    categories = ["command", "impact"]
     authors = ["bartblaze"]
     minimum = "1.3"
     ttps = ["T1485"]
@@ -468,7 +468,7 @@ class UsesWindowsUtilitiesClickOnce(Signature):
     name = "uses_windows_utilities_clickonce"
     description = "Uses ClickOnce Deployment Manifests for download or installation"
     severity = 1
-    categories = ["commands", "evasion"]
+    categories = ["command", "evasion"]
     authors = ["bartblaze"]
     minimum = "1.3"
     references = ["http://blog.redxorblue.com/2020/07/one-click-to-compromise-fun-with.html"]
@@ -499,7 +499,7 @@ class UsesWindowsUtilitiesMode(Signature):
     name = "uses_windows_utilities_mode"
     description = "Uses MODE to configure a system device or change the code page"
     severity = 1
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["bartblaze"]
     minimum = "1.3"
     references = ["https://www.robvanderwoude.com/mode.php"]
@@ -676,7 +676,7 @@ class SuspiciousMpCmdRunUse(Signature):
     name = "suspicious_mpcmdrun_use"
     description = "Suspicious use of MpCmdRun was detected"
     severity = 3
-    categories = ["commands"]
+    categories = ["command"]
     authors = ["ditekshen"]
     minimum = "1.3"
     evented = True
@@ -700,7 +700,7 @@ class MultipleExplorerInstances(Signature):
     name = "multiple_explorer_instances"
     description = "Spawns another instance of explorer"
     severity = 2
-    categories = ["commands", "evasion"]
+    categories = ["command", "evasion"]
     authors = ["bartblaze"]
     minimum = "1.3"
     references = ["https://twitter.com/CyberRaiju/status/1273597319322058752"]


### PR DESCRIPTION
Made the following changes:
- `antiav` -> `anti-av` which is more commonly used
- `antisandbox` -> `anti-sandbox` which is more commonly used
- `antivm` -> `anti-vm` which is more commonly used
- Changing all categories to lowercase
- Moving `clamav` to generic `antivirus` category used by the Virustotal AV hit signature
- `commands` -> `command` which is more commonly used
- `lateral_movement` -> `lateral`
- `miner` and `miners` -> `cryptomining`
- `macros` -> `macro`
- `exploitation` -> `exploit`