### PR TITLE
Changing mark names for consistency

### DIFF
--- a/modules/signatures/dead_link.py
+++ b/modules/signatures/dead_link.py
@@ -46,7 +46,7 @@ class DeadLink(Signature):
                         break
             if deadnames:
                 for deadname in deadnames:
-                    self.data.append({"dead_binary": deadname})
+                    self.data.append({"binary": deadname})
                 return True
 
         return False

--- a/modules/signatures/execution_suspicious.py
+++ b/modules/signatures/execution_suspicious.py
@@ -45,8 +45,8 @@ class ProcessCreationSuspiciousLocation(Signature):
             for suspiciouspath in self.suspicious_paths:
                 if suspiciouspath in appname:
                     self.ret = True
-                    self.data.append({"File executed": appname})
-                    self.data.append({"Commandline executed": cmdline})
+                    self.data.append({"file": appname})
+                    self.data.append({"command": cmdline})
 
     def on_complete(self):
         return self.ret


### PR DESCRIPTION
"binary", "file" and "command" are more common mark names than these one-offs.