### PR TITLE
Removing unnecessary list for mark value

### DIFF
--- a/modules/signatures/remcos.py
+++ b/modules/signatures/remcos.py
@@ -37,7 +37,7 @@ class RemcosFiles(Signature):
         for indicator in indicators:
             match = self.check_file(pattern=indicator, regex=True)
             if match:
-                self.data.append({"file": [match]})
+                self.data.append({"file": match})
                 return True
 
         return False


### PR DESCRIPTION
From what I can find, this issue is only present for the remcos_files signature