### PR TITLE
fix misplace mbc tags & typo

### DIFF
--- a/modules/signatures/bootkit.py
+++ b/modules/signatures/bootkit.py
@@ -161,7 +161,7 @@ class SuspiciousIoctlSCSIPassthough(Signature):
     evented = True
     ttps = ["T1067"]  # MITRE v6
     ttps += ["T1542", "T1542.003"]  # MITRE v7,8
-    mbcs = ["0B0006", "F0013"]
+    mbcs = ["OB0006", "F0013"]
     references = ["http://www.ioctls.net/"]
 
     filter_apinames = set(["DeviceIoControl", "NtDeviceIoControlFile"])

--- a/modules/signatures/persistence_autorun.py
+++ b/modules/signatures/persistence_autorun.py
@@ -224,7 +224,7 @@ class PersistenceSafeBoot(Signature):
     ttps = ["T1060"]  # MITRE v6
     ttps += ["T1112"]  # MITRE v6,7,8
     ttps += ["T1547", "T1547.001"]  # MITRE v7,8
-    ttps += ["OB0012", "E1112"]
+    mbcs += ["OB0012", "E1112"]
 
     def run(self):
         indicators = [

--- a/modules/signatures/powershell_command.py
+++ b/modules/signatures/powershell_command.py
@@ -343,17 +343,17 @@ class PowerShellNetworkConnection(Signature):
                 self.data.append({"request": buff})
                 self.mark_call()
             if call["api"] == "HttpOpenRequestW":
-                self.ttps += ["OC0006", "C0002"]
+                self.mbcs += ["OC0006", "C0002"]
                 buff = self.get_argument(call, "Path").lower()
                 self.data.append({"request": buff})
                 self.mark_call()
             if call["api"] == "InternetCrackUrlW":
-                self.ttps += ["OC0006", "C0005"]
+                self.mbcs += ["OC0006", "C0005"]
                 buff = self.get_argument(call, "Url").lower()
                 self.data.append({"request": buff})
                 self.mark_call()
             if call["api"] == "InternetCrackUrlA":
-                self.ttps += ["OC0006", "C0005"]
+                self.mbcs += ["OC0006", "C0005"]
                 buff = self.get_argument(call, "Url").lower()
                 self.data.append({"request": buff})
                 self.mark_call()

--- a/modules/signatures/reads_self.py
+++ b/modules/signatures/reads_self.py
@@ -75,7 +75,7 @@ class ReadsSelf(Signature):
     authors = ["Optiv"]
     minimum = "1.2"
     evented = True
-    ttps = ["OC0001", "C0051"]
+    mbcs = ["OC0001", "C0051"]
 
     filter_analysistypes = set(["file"])
     filter_apinames = set(["NtOpenFile", "NtCreateFile", "NtClose", "NtReadFile", "NtSetInformationFile"])


### PR DESCRIPTION
I notice that some of the mbcs are put in the ttps array.
And also one typo "0B0006" -> "OB0006"