### PR TITLE
Using run for nonevented sig, updating indicator regex

### DIFF
--- a/modules/signatures/network_cnc_http.py
+++ b/modules/signatures/network_cnc_http.py
@@ -162,8 +162,8 @@ class NetworkIPEXE(Signature):
     authors = ["@CybercentreCanada"]
     minimum = "1.2"
 
-    def on_complete(self):
-        indicator = "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*\.exe"
+    def run(self):
+        indicator = "(https?://)?\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*\.exe"
         # Downloading an EXE from an IP is ALWAYS SKETCHY
         matches = self.check_url(pattern=indicator, regex=True, all=True)
         for match in matches:


### PR DESCRIPTION
Signature was not running because it relied on `on_complete` to be called, but that is for evented signatures only.

Indicator regex did not match any valid URI since it required a URI to start with an IP