### PR TITLE
Check if matches exist before iterating

### DIFF
--- a/modules/signatures/network_cnc_http.py
+++ b/modules/signatures/network_cnc_http.py
@@ -166,8 +166,9 @@ class NetworkIPEXE(Signature):
         indicator = "(https?://)?\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*\.exe"
         # Downloading an EXE from an IP is ALWAYS SKETCHY
         matches = self.check_url(pattern=indicator, regex=True, all=True)
-        for match in matches:
-            self.data.append({"request": match})
+        if matches:
+            for match in matches:
+                self.data.append({"request": match})
 
         if len(self.data) > 0:
             return True


### PR DESCRIPTION
If ask for all matches from `check_url` and there are no matches, I should get an empty list or set, but that's a bigger problem so for now this will fix the issue.