### PR TITLE
Tweaking scores and adding safelists of processes

### DIFF
--- a/modules/signatures/antidebug_setunhandledexceptionfilter.py
+++ b/modules/signatures/antidebug_setunhandledexceptionfilter.py
@@ -21,6 +21,7 @@ class antidebug_setunhandledexceptionfilter(Signature):
     name = "antidebug_setunhandledexceptionfilter"
     description = "SetUnhandledExceptionFilter detected (possible anti-debug)"
     severity = 1
+    confidence = 40
     categories = ["anti-debug"]
     authors = ["redsand"]
     minimum = "1.3"

--- a/modules/signatures/antivm_network_adapter.py
+++ b/modules/signatures/antivm_network_adapter.py
@@ -19,7 +19,8 @@ from lib.cuckoo.common.abstracts import Signature
 class NetworkAdapters(Signature):
     name = "antivm_network_adapters"
     description = "Checks adapter addresses which can be used to detect virtual network interfaces"
-    severity = 2
+    severity = 1
+    confidence = 40
     categories = ["anti-vm"]
     # Migrated by @CybercentreCanada
     authors = ["Kevin Ross", "@CybercentreCanada"]
@@ -30,7 +31,7 @@ class NetworkAdapters(Signature):
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
-        self.safelistprocs = ["iexplore.exe", "firefox.exe", "chrome.exe", "safari.exe", "outlook.exe"]
+        self.safelistprocs = ["iexplore.exe", "firefox.exe", "chrome.exe", "safari.exe", "outlook.exe", "winword.exe", "excel.exe", "powerpnt.exe"]
 
     def on_call(self, _, process):
         if process["process_name"].lower() not in self.safelistprocs:

--- a/modules/signatures/crypto_apis.py
+++ b/modules/signatures/crypto_apis.py
@@ -29,7 +29,7 @@ class CryptGenKey(Signature):
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
-        self.process_safelist = ["powershell.exe"]
+        self.process_safelist = ["powershell.exe", "winword.exe", "powerpnt.exe", "excel.exe"]
 
     def on_call(self, _, process):
         if process["process_name"] in self.process_safelist:

--- a/modules/signatures/dll_load_uncommon.py
+++ b/modules/signatures/dll_load_uncommon.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 class DllLoadUncommonFileTypes(Signature):
     name = "dll_load_uncommon_file_types"
     description = "A file with an unusual extension was attempted to be loaded as a DLL."
-    severity = 2
+    severity = 1
     categories = ["anti-debug"]
     authors = ["@CybercentreCanada"]
     minimum = "1.2"

--- a/modules/signatures/dynamic_function_loading.py
+++ b/modules/signatures/dynamic_function_loading.py
@@ -21,6 +21,7 @@ class dynamic_function_loading(Signature):
     name = "dynamic_function_loading"
     description = "Dynamic (imported) function loading detected"
     severity = 1
+    confidence = 40
     categories = ["anti-debug"]
     authors = ["redsand"]
     minimum = "1.3"

--- a/modules/signatures/exploit_heapspray.py
+++ b/modules/signatures/exploit_heapspray.py
@@ -19,7 +19,7 @@ from lib.cuckoo.common.abstracts import Signature
 class ExploitHeapspray(Signature):
     name = "exploit_heapspray"
     description = "A possible heap spray exploit has been detected"
-    severity = 3
+    severity = 1
     confidence = 40
     categories = ["exploit"]
     authors = ["Cuckoo Technologies", "Kevin Ross"]
@@ -41,15 +41,12 @@ class ExploitHeapspray(Signature):
             "acrobat.exe",
             "acrord32.exe",
             "chrome.exe",
-            "excel.exe",
             "FLTLDR.EXE",
             "firefox.exe",
             "HimTrayIcon.exe",
             "hwp.exe",
             "iexplore.exe",
             "outlook.exe",
-            "powerpnt.exe",
-            "winword.exe",
         ]
 
     def on_call(self, call, process):

--- a/modules/signatures/malware_data_encryption.py
+++ b/modules/signatures/malware_data_encryption.py
@@ -19,7 +19,7 @@ from lib.cuckoo.common.abstracts import Signature
 class EncryptPCInfo(Signature):
     name = "encrypt_pcinfo"
     description = "Collects and encrypts information about the computer likely to send to C2 server"
-    severity = 3
+    severity = 1
     categories = ["c2", "encryption"]
     authors = ["Kevin Ross"]
     minimum = "0.5"
@@ -37,22 +37,24 @@ class EncryptPCInfo(Signature):
         self.compname = str()
         self.username = str()
         self.buffers = set()
+        self.safelistprocs = ["winword.exe", "excel.exe", "powerpnt.exe"]
 
     def on_call(self, call, process):
-        if call["api"] == "GetComputerNameW":
-            self.compname = self.get_argument(call, "ComputerName")
+        if process["process_name"].lower() not in self.safelistprocs:
+            if call["api"] == "GetComputerNameW":
+                self.compname = self.get_argument(call, "ComputerName")
 
-        if call["api"] == "GetUserNameW":
-            self.username = self.get_argument(call, "Name")
+            if call["api"] == "GetUserNameW":
+                self.username = self.get_argument(call, "Name")
 
-        if call["api"].startswith("Crypt"):
-            buff = self.get_argument(call, "Buffer")
-            if buff and (self.username or self.compname):
-                if self.compname.lower() in buff.lower() or self.username.lower() in buff.lower():
-                    self.ret = True
-                    self.buffers.add(buff)
-                    if self.pid:
-                        self.mark_call()
+            if call["api"].startswith("Crypt"):
+                buff = self.get_argument(call, "Buffer")
+                if buff and (self.username or self.compname):
+                    if self.compname.lower() in buff.lower() or self.username.lower() in buff.lower():
+                        self.ret = True
+                        self.buffers.add(buff)
+                        if self.pid:
+                            self.mark_call()
 
     def on_complete(self):
         for buffer in self.buffers:

--- a/modules/signatures/office_dll_loading.py
+++ b/modules/signatures/office_dll_loading.py
@@ -78,7 +78,7 @@ from lib.cuckoo.common.abstracts import Signature
 class OfficeVBLLoad(Signature):
     name = "office_vb_load"
     description = "Office loads VB DLLs, indicative of Office Macros"
-    severity = 2
+    severity = 1
     categories = ["office", "macro"]
     authors = ["ditekshen"]
     minimum = "1.3"
@@ -143,7 +143,7 @@ class OfficeWMILoad(Signature):
 class OfficeCOMLoad(Signature):
     name = "office_com_load"
     description = "Office loads COM DLLs, indicative of Office Macros spawning CMD process for execution"
-    severity = 2
+    severity = 1
     categories = ["office", "macro"]
     authors = ["ditekshen"]
     minimum = "1.3"

--- a/modules/signatures/stack_pivot.py
+++ b/modules/signatures/stack_pivot.py
@@ -48,15 +48,12 @@ class StackPivot(Signature):
             "acrobat.exe",
             "acrord32.exe",
             "chrome.exe",
-            "excel.exe",
             "FLTLDR.EXE",
             "firefox.exe",
             "HimTrayIcon.exe",
             "hwp.exe",
             "iexplore.exe",
             "outlook.exe",
-            "powerpnt.exe",
-            "winword.exe",
         ]
 
     def on_call(self, call, process):

--- a/modules/signatures/stealth_timelimit.py
+++ b/modules/signatures/stealth_timelimit.py
@@ -8,8 +8,8 @@ from lib.cuckoo.common.abstracts import Signature
 class StealthTimeout(Signature):
     name = "stealth_timeout"
     description = "Possible date expiration check, exits too soon after checking local time"
-    severity = 2
-    confidence = 50
+    severity = 1
+    confidence = 40
     categories = ["stealth"]
     authors = ["Optiv"]
     minimum = "1.3"


### PR DESCRIPTION
Based on a sample set of > 100k safe Office documents, these are the signatures that cause the most FPs.