### PR TITLE
 check NtCreateUserProcess API as well for the deletes_shadow_copies sig

### DIFF
--- a/modules/signatures/deletes_shadowcopies.py
+++ b/modules/signatures/deletes_shadowcopies.py
@@ -16,7 +16,7 @@ class DeletesShadowCopies(Signature):
     ttps = ["T1490"]  # MITRE v6,7,8
     mbcs = ["OB0008", "F0014", "F0014.001"]
 
-    filter_apinames = set(["CreateProcessInternalW", "ShellExecuteExW"])
+    filter_apinames = set(["CreateProcessInternalW", "ShellExecuteExW", "NtCreateUserProcess"])
 
     def on_call(self, call, process):
         if call["api"] == "CreateProcessInternalW":

--- a/modules/signatures/deletes_shadowcopies.py
+++ b/modules/signatures/deletes_shadowcopies.py
@@ -10,7 +10,7 @@ class DeletesShadowCopies(Signature):
     description = "Attempts to delete or modify volume shadow copies"
     severity = 3
     categories = ["ransomware"]
-    authors = ["Optiv"]
+    authors = ["Optiv", "Zane C. Bowers-Hadley"]
     minimum = "1.2"
     evented = True
     ttps = ["T1490"]  # MITRE v6,7,8
@@ -45,6 +45,20 @@ class DeletesShadowCopies(Signature):
                     self.mark_call()
                 return True
             elif "wmic" in filepath and "shadowcopy" in params and "delete" in params:
+                if self.pid:
+                    self.mark_call()
+                return True
+        elif call["api"] == "NtCreateUserProcess":
+            cmd_line = self.get_argument(call, "CommandLine").lower()
+            if (
+                "vssadmin" in cmd_line
+                and ("delete" in cmd_line and "shadows" in cmd_line)
+                or ("resize" in cmd_line and "shadowstorage" in cmd_line)
+            ):
+                if self.pid:
+                    self.mark_call()
+                return True
+            elif "wmic" in cmd_line and "shadowcopy" in cmd_line and "delete" in cmd_line:
                 if self.pid:
                     self.mark_call()
                 return True


### PR DESCRIPTION
Found vssadmin was being called in a sample I was handed. Went to write a sig for it and found deletes_shadow_copies, but it was not triggering. When looking at it, I found that it was missing checking NtCreateUserProcess, which in this case was what was being used to call it.