### PR TITLE
add NtCreateUserProcess checking in a few more places

### DIFF
--- a/modules/signatures/bcdedit_command.py
+++ b/modules/signatures/bcdedit_command.py
@@ -31,7 +31,7 @@ class BCDEditCommand(Signature):
     mbcs = ["OB0006", "E1478", "OB0009", "E1059"]
     mbcs += ["OC0008", "C0033"]  # micro-behaviour
 
-    filter_apinames = set(["CreateProcessInternalW", "ShellExecuteExW"])
+    filter_apinames = set(["CreateProcessInternalW", "ShellExecuteExW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -42,6 +42,8 @@ class BCDEditCommand(Signature):
 
     def on_call(self, call, process):
         if call["api"] == "CreateProcessInternalW":
+            cmdline = self.get_argument(call, "CommandLine").lower()
+        elif call["api"] == "NtCreateUserProcess":
             cmdline = self.get_argument(call, "CommandLine").lower()
         else:
             filepath = self.get_argument(call, "FilePath").lower()

--- a/modules/signatures/bcdedit_command.py
+++ b/modules/signatures/bcdedit_command.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Kevin Ross
+# Copyright (C) 2022 Kevin Ross
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@ class BCDEditCommand(Signature):
     confidence = 20
     weight = 0
     categories = ["generic"]
-    authors = ["Kevin Ross"]
+    authors = ["Kevin Ross", "Zane C. Bowers-Hadley"]
     minimum = "1.2"
     evented = True
     ttps = ["T1059"]  # MITRE v6,7,8

--- a/modules/signatures/compile_dotnet_code.py
+++ b/modules/signatures/compile_dotnet_code.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 ditekshen
+# Copyright (C) 2022 ditekshen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ class CompilesDotNetCode(Signature):
     description = "Compiles .NET code into an executable and executes it"
     severity = 3
     categories = ["evasion", "execution", "dropper", "dotnet", "exploit", "office"]
-    authors = ["ditekshen"]
+    authors = ["ditekshen", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1500"]  # MITRE v6
@@ -34,7 +34,7 @@ class CompilesDotNetCode(Signature):
     ttps += ["T1027.004"]  # MITRE v7,8
     mbcs = ["OB0002", "E1027"]
 
-    filter_apinames = set(["CreateProcessInternalA", "CreateProcessInternalW", "NtWriteFile"])
+    filter_apinames = set(["CreateProcessInternalA", "CreateProcessInternalW", "NtWriteFile", "NtCreateUserProcess"])
     filter_analysistypes = set(["file"])
 
     def __init__(self, *args, **kwargs):
@@ -45,7 +45,11 @@ class CompilesDotNetCode(Signature):
         self.writemz = False
 
     def on_call(self, call, process):
-        if call["api"] == "CreateProcessInternalA" or call["api"] == "CreateProcessInternalW":
+        if (
+                call["api"] == "CreateProcessInternalA"
+                or call["api"] == "CreateProcessInternalW"
+                or call["api"] == "NtCreateUserProcess"
+            ):
             cmdline = self.get_argument(call, "CommandLine")
             if cmdline:
                 if "csc.exe" in cmdline or "vbc.exe" in cmdline:
@@ -54,7 +58,11 @@ class CompilesDotNetCode(Signature):
 
         processname = process["process_name"].lower()
         if processname == "csc.exe" or processname == "vbc.exe":
-            if call["api"] == "CreateProcessInternalA" or call["api"] == "CreateProcessInternalW":
+            if (
+                    call["api"] == "CreateProcessInternalA"
+                    or call["api"] == "CreateProcessInternalW"
+                    or call["api"] == "NtCreateUserProcess"
+            ):
                 cmdline = self.get_argument(call, "CommandLine")
                 if cmdline:
                     if "cvtres.exe" in cmdline:

--- a/modules/signatures/disables_drives_autodisconnect.py
+++ b/modules/signatures/disables_drives_autodisconnect.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 ditekshen
+# Copyright (C) 2022 ditekshen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,16 +21,22 @@ class DisablesMappedDrivesAutodisconnect(Signature):
     description = "Attempts to disable or change the mapped dirves autodisconnect feature via command line"
     severity = 3
     categories = ["ransomware"]
-    authors = ["ditekshen"]
+    authors = ["ditekshen", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1059"]  # MITRE v6,7,8
     mbcs = ["OB0009", "E1059"]
 
-    filter_apinames = set(["CreateProcessInternalW", "ShellExecuteExW"])
+    filter_apinames = set(["CreateProcessInternalW", "ShellExecuteExW", "NtCreateUserProcess"])
 
     def on_call(self, call, process):
         if call["api"] == "CreateProcessInternalW":
+            cmdline = self.get_argument(call, "CommandLine").lower()
+            if "config server" in cmdline and "/autodisconnect:" in cmdline and "net" in cmdline:
+                if self.pid:
+                    self.mark_call()
+                return True
+        if call["api"] == "NtCreateUserProcess":
             cmdline = self.get_argument(call, "CommandLine").lower()
             if "config server" in cmdline and "/autodisconnect:" in cmdline and "net" in cmdline:
                 if self.pid:

--- a/modules/signatures/exploitation_framework_koadic.py
+++ b/modules/signatures/exploitation_framework_koadic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ditekshen
+# Copyright (C) 2022 ditekshen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,11 +27,11 @@ class KoadicAPIs(Signature):
     severity = 3
     categories = ["exploit"]
     families = ["Koadic"]
-    authors = ["ditekshen"]
+    authors = ["ditekshen", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
 
-    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess", "ShellExecuteExW", "NtWriteFile"])
+    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess", "ShellExecuteExW", "NtWriteFile", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -47,7 +47,11 @@ class KoadicAPIs(Signature):
     def on_call(self, call, process):
         processname = process["process_name"].lower()
         if processname == "mshta.exe" or processname == "rundll32.exe":
-            if call["api"] == "NtCreateUserProcess" or call["api"] == "CreateProcessInternalW":
+            if (
+                    call["api"] == "NtCreateUserProcess"
+                    or call["api"] == "CreateProcessInternalW"
+                    or call["api"] == "NtCreateUserProcess"
+                ):
                 cmdline = self.get_argument(call, "CommandLine")
                 if cmdline:
                     for pat in self.patterns:

--- a/modules/signatures/injection_needextension.py
+++ b/modules/signatures/injection_needextension.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Optiv, Inc. (brad.spengler@optiv.com)
+# Copyright (C) 2022 Optiv, Inc. (brad.spengler@optiv.com)
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
@@ -10,12 +10,12 @@ class InjectionExtension(Signature):
     description = "Attempted to execute a copy of itself but requires an .exe extension to work"
     severity = 3
     categories = ["injection"]
-    authors = ["Optiv"]
+    authors = ["Optiv", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     mbcs = ["OC0001", "C0045"]  # micro-behaviour
 
-    filter_apinames = set(["CreateProcessInternalW"])
+    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess"])
 
     def on_call(self, call, process):
         if call["status"] == False:

--- a/modules/signatures/ransomware_sodinokibi.py
+++ b/modules/signatures/ransomware_sodinokibi.py
@@ -15,7 +15,7 @@ class sodinokibi(Signature):
     severity = 3
     categories = ["ransomware"]
     families = ["Sodinokibi"]
-    authors = ["@NaxoneZ"]
+    authors = ["@NaxoneZ", "Zane C. Bowers-Hadley"]
     minimum = "1.2"
     evented = True
     ttps = ["T1486"]  # MITRE v6,7,8
@@ -25,7 +25,7 @@ class sodinokibi(Signature):
     # Sodinokibi:
     # 1. 03eb9b0e4e842cbe3726872ed46e241f5b79e18a09e1655341a403ac3e5136a6 (variant1)
 
-    filter_apinames = set(["RegSetValueExW", "CreateProcessInternalW", "WinHttpOpen", "bind"])
+    filter_apinames = set(["RegSetValueExW", "CreateProcessInternalW", "WinHttpOpen", "bind", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -42,7 +42,10 @@ class sodinokibi(Signature):
                     if self.pid:
                         self.mark_call()
 
-        if call["api"] == "CreateProcessInternalW":
+        if (
+                call["api"] == "CreateProcessInternalW"
+                or call["api"] == "NtCreateUserProcess"
+        ):
             node = self.get_argument(call, "CommandLine")
             if powershell in node:
                 self.badness_powershell += 1

--- a/modules/signatures/rat_trochilus.py
+++ b/modules/signatures/rat_trochilus.py
@@ -28,7 +28,7 @@ class TrochilusRATAPIs(Signature):
     ttps = ["T1219"]  # MITRE v6,7,8
     mbcs = ["B0022"]
 
-    filter_apinames = set(["OutputDebugStringW", "CreateProcessInternalW", "RegSetValueExW"])
+    filter_apinames = set(["OutputDebugStringW", "CreateProcessInternalW", "RegSetValueExW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -43,7 +43,10 @@ class TrochilusRATAPIs(Signature):
                     if self.pid:
                         self.mark_call()
 
-        if call["api"] == "CreateProcessInternalW":
+        if (
+                call["api"] == "CreateProcessInternalW"
+                or call["api"] == "NtCreateUserProcess"
+        ):
             cmdline = self.get_argument(call, "CommandLine")
             if cmdline:
                 if "XLServant" in cmdline:

--- a/modules/signatures/script_downloader.py
+++ b/modules/signatures/script_downloader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Kevin Ross
+# Copyright (C) 2022 Kevin Ross
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -171,7 +171,7 @@ class ScriptCreatedProcess(Signature):
     severity = 3
     confidence = 100
     categories = ["downloader", "dropper"]
-    authors = ["Kevin Ross"]
+    authors = ["Kevin Ross", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1064"]  # MITRE v6
@@ -179,7 +179,7 @@ class ScriptCreatedProcess(Signature):
     mbcs = ["OB0009", "E1059"]
     mbcs += ["OC0003", "C0017"]  # micro-behaviour
 
-    filter_apinames = set(["CreateProcessInternalW"])
+    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)

--- a/modules/signatures/stack_pivot.py
+++ b/modules/signatures/stack_pivot.py
@@ -130,14 +130,14 @@ class StackPivotProcessCreate(Signature):
     severity = 3
     confidence = 100
     categories = ["exploit"]
-    authors = ["Kevin Ross"]
+    authors = ["Kevin Ross", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1203"]  # MITRE v6,7,8
     mbcs = ["OB0009", "E1203"]
     mbcs += ["OC0003", "C0017"]  # micro-behaviour
 
-    filter_apinames = set(["CreateProcessInternalW"])
+    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)

--- a/modules/signatures/stealth_childproc.py
+++ b/modules/signatures/stealth_childproc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Optiv, Inc. (brad.spengler@optiv.com)
+# Copyright (C) 2022 Optiv, Inc. (brad.spengler@optiv.com)
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
@@ -11,12 +11,12 @@ class StealthChildProc(Signature):
     severity = 3
     confidence = 100
     categories = ["stealth"]
-    authors = ["Optiv"]
+    authors = ["Optiv", "Zane C. Bowers-Hadley"]
     minimum = "1.2"
     evented = True
     references = ["https://www.countercept.com/blog/detecting-parent-pid-spoofing/"]
 
-    filter_apinames = set(["NtCreateProcess", "NtCreateProcessEx", "RtlCreateUserProcess", "CreateProcessInternalW"])
+    filter_apinames = set(["NtCreateProcess", "NtCreateProcessEx", "RtlCreateUserProcess", "CreateProcessInternalW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)

--- a/modules/signatures/whitelisting_bypass_dev_utils.py
+++ b/modules/signatures/whitelisting_bypass_dev_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 ditekshen
+# Copyright (C) 2022 ditekshen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -76,14 +76,14 @@ class SpwansDotNetDevUtiliy(Signature):
     description = "Attempts to bypass application whitelisting"
     severity = 3
     categories = ["masquerading", "evasion", "execution", "dotnet"]
-    authors = ["ditekshen"]
+    authors = ["ditekshen", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1118"]  # MITRE v6
     ttps += ["T1127", "T1218"]  # MITRE v6,7,8
     ttps += ["T1218.004"]  # MITRE v7,8
 
-    filter_apinames = set(["CreateProcessInternalA", "CreateProcessInternalW", "CopyFileA", "CopyFileW", "CopyFileExW"])
+    filter_apinames = set(["CreateProcessInternalA", "CreateProcessInternalW", "CopyFileA", "CopyFileW", "CopyFileExW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -110,7 +110,11 @@ class SpwansDotNetDevUtiliy(Signature):
                     if re.search(tool, self.sname.lower()):
                         self.dname = self.get_argument(call, "NewFileName")
 
-        if call["api"] == "CreateProcessInternalA" or call["api"] == "CreateProcessInternalW":
+        if (
+                call["api"] == "CreateProcessInternalA"
+                or call["api"] == "CreateProcessInternalW"
+                or call["api"] == "NtCreateUserProcess"
+        ):
             cmdline = self.get_argument(call, "CommandLine").lower()
             appname = self.get_argument(call, "ApplicationName")
             if cmdline:

--- a/modules/signatures/wmi.py
+++ b/modules/signatures/wmi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Kevin Ross
+# Copyright (C) 2022 Kevin Ross
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,13 +22,13 @@ class WMICreateProcess(Signature):
     severity = 3
     confidence = 50
     categories = ["martians"]
-    authors = ["Kevin Ross"]
+    authors = ["Kevin Ross", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1047"]  # MITRE v6,7,8
     mbcs = ["OC0003", "C0017", "C0017.002"]  # micro-behaviour
 
-    filter_apinames = set(["CreateProcessInternalW"])
+    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -62,14 +62,14 @@ class WMIScriptProcess(Signature):
     severity = 3
     confidence = 100
     categories = ["martians"]
-    authors = ["Kevin Ross"]
+    authors = ["Kevin Ross", "Zane C. Bowers-Hadley"]
     minimum = "1.3"
     evented = True
     ttps = ["T1064"]  # MITRE v6
     ttps += ["T1047", "T1059"]  # MITRE v6,7,8
     mbcs = ["OB0009", "E1059"]
 
-    filter_apinames = set(["CreateProcessInternalW"])
+    filter_apinames = set(["CreateProcessInternalW", "NtCreateUserProcess"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)


### PR DESCRIPTION
So  #324 got me thinking where else this may be relevant. So I went through looking for at other places CreateProcessInternalW or ShellExecuteExW were used and added NtCreateUserProcess where it should be relevant.

Pretty much any where that CreateProcessInternalW is used with the arg CommandLine, checking NtCreateUserProcess as well is likely a good idea.
