### PR TITLE
Fix network_payload_downaload signature with wrong argument name

### DIFF
--- a/modules/signatures/network_payload_download.py
+++ b/modules/signatures/network_payload_download.py
@@ -93,7 +93,12 @@ class NetworkEXE(Signature):
         ]
 
     def on_call(self, call, process):
-        buf = self.get_argument(call, "buffer")
+        if call["api"] == "recv":
+            buf = self.get_argument(call, "buffer")
+        elif call["api"] == "InternetReadFile":
+            buf = self.get_argument(call, "Buffer")
+        else:
+            return
         pname = process["process_name"].lower()
         if buf and "MZ" in buf and "This program" in buf:
             if pname in self.high_risk_proc:


### PR DESCRIPTION
- `recv` has argument "buffer"
- `InternetReadFile` has argument "Buffer"