### PR TITLE
Avoiding FPs for office CVE exploit

### DIFF
--- a/modules/signatures/office_exploit.py
+++ b/modules/signatures/office_exploit.py
@@ -334,7 +334,7 @@ class OfficeCVE202140444M2(Signature):
 
     def on_complete(self):
         for key in self.htmlfcnt_office:
-            # print(self.htmlfcnt_office[key])
+            
             tmp_dict = {
                 "office_cve_2021_40444": "pname:%s htmlfile:%s has_cab_dl:%s has_known_bad_clsid:%s has_shellmatch:%s is_ie:%s has_jscript:%s dot_proto_url:%s"
                 % (
@@ -381,5 +381,8 @@ class OfficeCVE202140444M2(Signature):
             if self.global_has_dot_proto_url and self.global_htmlfile_max > 0:
                 self.data.append({"office_cve_2021_40444": "Cumulative behavior detected htmlfile ActiveXObject and Dotproto URL"})
         if self.data:
+            # If the only data is marked calls, this is an FP
+            if all(item.get("type") == "call" for item in self.data):
+                return False
             return True
         return False


### PR DESCRIPTION
This signature is seen being falsely raised whenever IE launches an HTML file for a benign webpage such as google.com. This looks like a regression from https://github.com/cccs-kevin/community-1/commit/1ba482d034327919ae83a653d294c3aab7b1c1b4#diff-8ddc70403e284237d5742c1864a6ddd4979857d74b8e0d270d8c484e6186eb4d.

Therefore we should check if the only data is that of marked calls and if so it is a FP.