### PR TITLE
add a fix for if a report has zero dropped files

### DIFF
--- a/modules/reporting/runstatistics.py
+++ b/modules/reporting/runstatistics.py
@@ -16,11 +16,7 @@ class RunStatistics(Report):
         """Count DroppedFiles.
         @return int value.
         """
-        try:
-            count = len(results.get("dropped"))
-        except Exception as e:
-            count = 0
-        return count
+        return len(results.get("dropped", ""))
 
     def getRuningProcessesCount(self, results):
         """Count running processes.

--- a/modules/reporting/runstatistics.py
+++ b/modules/reporting/runstatistics.py
@@ -16,7 +16,11 @@ class RunStatistics(Report):
         """Count DroppedFiles.
         @return int value.
         """
-        return len(results.get("dropped"))
+        try:
+            count = len(results.get("dropped"))
+        except Exception as e:
+            count = 0
+        return count
 
     def getRuningProcessesCount(self, results):
         """Count running processes.


### PR DESCRIPTION
Fixes errors for runs in which zero files were dropped.

```
2023-01-25 16:11:52,768 [Task 95110] [lib.cuckoo.core.plugins] ERROR: Failed to run the reporting module "RunStatistics": object of type 'NoneType' has no len()
Traceback (most recent call last):
  File "/opt/CAPEv2/utils/../lib/cuckoo/core/plugins.py", line 715, in process
    current.run(self.results)
  File "/opt/CAPEv2/utils/../modules/reporting/runstatistics.py", line 93, in run
    detail["dropped_files"] = self.getDroppedFileCount(results)
  File "/opt/CAPEv2/utils/../modules/reporting/runstatistics.py", line 19, in getDroppedFileCount
    return len(results.get("dropped"))
TypeError: object of type 'NoneType' has no len()
```
