### PR TITLE
Make various updates to ransomware file modifications sig

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -23,53 +23,62 @@ except ImportError:
 
 class RansomwareFileModifications(Signature):
     name = "ransomware_file_modifications"
-    description = "Exhibits possible ransomware file modification behavior"
+    description = "Exhibits possible ransomware or wiper file modification behavior"
     severity = 3
     confidence = 50
-    categories = ["ransomware"]
+    categories = ["ransomware", "wiper"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
     ttps = ["T1486"]  # MITRE v6,7,8
     mbcs = ["OB0008", "E1486"]
 
-    filter_apinames = set(["MoveFileWithProgressW", "MoveFileWithProgressTransactedW"])
+    filter_apinames = set(["MoveFileWithProgressW", "MoveFileWithProgressTransactedW", "NtCreateFile"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.movefilecount = 0
         self.appendcount = 0
         self.appendemailcount = 0
+        self.modifiedexistingcount = 0
         self.newextensions = []
 
     def on_call(self, call, process):
         if not call["status"]:
             return None
-        origfile = self.get_argument(call, "ExistingFileName")
-        newfile = self.get_argument(call, "NewFileName")
-        if origfile.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") and newfile.find(
-            "\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\"
-        ):
-            return None
-        self.movefilecount += 1
-        if origfile != newfile and "@" not in newfile:
-            origextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", origfile)
-            if not origextextract:
+        if call["api"].startswith("MoveFileWithProgress"):
+            origfile = self.get_argument(call, "ExistingFileName")
+            newfile = self.get_argument(call, "NewFileName")
+            if origfile.find("\\AppData\\Local\\Microsoft\\Windows\\Explorer\\iconcache_") and newfile.find(
+                "\\AppData\\Local\\Microsoft\\Windows\\Explorer\\IconCacheToDelete\\"
+            ):
                 return None
-            origextension = origextextract.group(1)
-            newextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", newfile)
-            if not newextextract:
-                return None
-            newextension = newextextract.group(1)
-            if newextension != ".tmp":
-                if origextension != newextension:
-                    self.appendcount += 1
-                    if self.newextensions.count(newextension) == 0:
-                        self.newextensions.append(newextension)
-        if origfile != newfile and "@" in newfile:
-            self.appendemailcount += 1
-            if self.pid:
-                self.mark_call()
+            self.movefilecount += 1
+            if origfile != newfile and "@" not in newfile:
+                origextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", origfile)
+                if not origextextract:
+                    return None
+                origextension = origextextract.group(1)
+                newextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", newfile)
+                if not newextextract:
+                    return None
+                newextension = newextextract.group(1)
+                if newextension != ".tmp":
+                    if origextension != newextension:
+                        self.appendcount += 1
+                        if self.newextensions.count(newextension) == 0:
+                            self.newextensions.append(newextension)
+            if origfile != newfile and "@" in newfile:
+                self.appendemailcount += 1
+                if self.pid and self.appendemailcount <= 10:
+                    self.mark_call()
+
+        if call["api"] == "NtCreateFile":
+            existed = self.get_argument(call, "ExistedBefore")
+            if existed == "yes":
+                self.modifiedexistingcount += 1
+                if self.pid and self.modifiedexistingcount <= 10:
+                    self.mark_call()
 
     def on_complete(self):
         ret = False
@@ -84,34 +93,37 @@ class RansomwareFileModifications(Signature):
                 and not deletedfile.lower().endswith(".tmp")
             ):
                 deletedcount += 1
-        if deletedcount > 100:
-            self.data.append(
-                {
-                    "mass file_deletion": "Appears to have deleted %s files indicative of ransomware or wiper malware deleting files to prevent recovery"
-                    % (deletedcount)
-                }
-            )
+        if deletedcount > 60:
+            if ":" in self.description:
+                self.description += " mass_file_deletion"
+            else:
+                self.description += ": mass_file_deletion"
             self.mbcs += ["OC0001", "C0047"]  # micro-behaviour
             ret = True
 
-        if self.movefilecount > 60:
-            self.data.append(
-                {
-                    "file_modifications": "Performs %s file moves indicative of a potential file encryption process"
-                    % (self.movefilecount)
-                }
-            )
+        if self.movefilecount > 30:
+            if ":" in self.description:
+                self.description += " suspicious_file_moves"
+            else:
+                self.description += ": suspicious_file_moves"
             self.mbcs += ["OC0005", "C0027"]  # micro-behaviour
             ret = True
 
-        if self.appendemailcount > 60:
-            self.data.append(
-                {
-                    "appends_email": "Appears to have appended an email address onto %s files. This is used by ransomware which requires the user to email the attacker for payment/recovery actions"
-                    % (self.appendemailcount)
-                }
-            )
+        if self.appendemailcount > 30:
+            if ":" in self.description:
+                self.description += " appends_email_to_filenames"
+            else:
+                self.description += ": appends_email_to_filenames"	    
+            ret = True
 
+        if self.modifiedexistingcount > 50:
+            if ":" in self.description:
+                self.description += " overwrites_existing_files"
+            else:
+                self.description += ": overwrites_existing_files"	    
+            ret = True
+
+	# This needs tweaked. No longer works due to dropped files limits in CAPE
         if "dropped" in self.results:
             droppedunknowncount = 0
             for dropped in self.results["dropped"]:
@@ -120,12 +132,10 @@ class RansomwareFileModifications(Signature):
                 if mimetype == "data" and ".tmp" not in filename and "CryptnetUrlCache" not in filename:
                     droppedunknowncount += 1
             if droppedunknowncount > 50 and self.results["info"]["package"] != "pdf":
-                self.data.append(
-                    {
-                        "drops_unknown_mimetypes": "Drops %s unknown file mime types which may be indicative of encrypted files being written back to disk"
-                        % (droppedunknowncount)
-                    }
-                )
+                if ":" in self.description:
+                    self.description += " mass_drops_unknown_filetypes"
+                else:
+                    self.description += ": mass_drops_unknown_filetypes"
                 ret = True
 
         # Note: Always make sure this check is at bottom so that appended file extensions are underneath behavior alerts
@@ -133,15 +143,11 @@ class RansomwareFileModifications(Signature):
             # This check is to prevent any cases where there is a large number of unique appended extensions resulting in an overly large list
             newcount = len(self.newextensions)
             if newcount > 15:
-                self.data.append(
-                    {"appends_new_extension": "Appended %s unique file extensions to multiple modified files" % (newcount)}
-                )
+                if ":" in self.description:
+                    self.description += " overwrites_existing_files"
+                else:
+                    self.description += ": overwrites_existing_files"
                 self.mbcs += ["OC0001", "C0015"]  # micro-behaviour
-            if newcount < 16:
-                self.data.append({"appends_new_extension": "Appends a new file extension to multiple modified files"})
-                self.mbcs += ["OC0001", "C0015"]  # micro-behaviour
-                for newextension in self.newextensions:
-                    self.data.append({"new_appended_file_extension": newextension})
             ret = True
 
         return ret


### PR DESCRIPTION
First improvement/clean-up pass of this sig:

- Updated description to indicate potential for it being ransomware or a wiper
- Limit call marking to only first 10 calls. This is so it does not go crazy and mark a lot of calls.
- Updated behaviour to append to main description. This is due to them appearing after call markings which were not clear.
- Added in overwriting files that existed before using CreateFile. There are other APIs and things that can do this but need to research more.

Note: Some behaviours no longer work due to limits on dropped files, also this sig does not cover all ransomware modifications, possible methods to achieve these such as APIs or wipers (when they are messing with files and not just trashing MBR and things). A lot do trash files though. To cover these behaviours will research more families.

HermeticWiper
![image](https://user-images.githubusercontent.com/2414517/216140508-8c2141b3-7b1d-42b5-94fc-2c4ebb55ed41.png)
