### PR TITLE
Fixed 'Entrypoint of binary is located outside of any mapped sections'

### DIFF
--- a/modules/signatures/all/static_pe_anomaly.py
+++ b/modules/signatures/all/static_pe_anomaly.py
@@ -73,8 +73,7 @@ class PEAnomaly(Signature):
                     foundcodesec = False
                     foundnamedupe = False
                     lowrva = 0xFFFFFFFF
-                    imagebase = int(pe["imagebase"], 16)
-                    eprva = int(pe["entrypoint"], 16) - imagebase
+                    eprva = int(pe["entrypoint"], 16)
                     seennames = set()
                     for section in pe["sections"]:
                         if section["name"] in seennames:


### PR DESCRIPTION
Almost (all ?) submitted PE match the signature : '[Anomalous binary characteristics] : anomaly: Entrypoint of binary is located outside of any mapped sections'. Take as an example (https://capesandbox.com/analysis/31693) whose entrypoint is obviously inside the .text section.

In the detection code, entrypoint was wrongly considered as an absolute address and imagebase was subtracted from it.
