### PR TITLE
Update network_dns_suspicious.py

### DIFF
--- a/modules/signatures/windows/network_dns_suspicious.py
+++ b/modules/signatures/windows/network_dns_suspicious.py
@@ -532,7 +532,7 @@ class NetworkDNSURLShortener(Signature):
             "adflav\.com$",
             "aiy\.ooo$",
             "aka\.gr$",
-            "amzn\.to",
+            "amzn\.to$",
             "artist\.link$",
             "b2n\.ir$",
             "bc\.vc$",


### PR DESCRIPTION
Necessary in order to actually hit on the actual domains, the point need to be escaped or it can be any character. Also the domain need to be finishing there so it is not as a subdomain or else it is not a shortener. This should be a domain not an URI so no issue for this.