### PR TITLE
Add DecompressEXE signature for memory analysis

### DIFF
--- a/modules/signatures/windows/packer_decompress_buffer.py
+++ b/modules/signatures/windows/packer_decompress_buffer.py
@@ -39,7 +39,7 @@ class DecompressEXE(Signature):
             return None
         if call["api"] == "RtlDecompressBuffer":
             buf = self.get_argument(call, "UncompressedBuffer")
-            if buf.startswith("MZ"):
+            if buf and buf.startswith("MZ"):
                 self.ret = True
                 self.mark_call()    
 


### PR DESCRIPTION
This module defines a signature for detecting decompression of executables in memory, which may indicate the use of packers or manual loaders.

Pikabot:
<img width="2052" height="779" alt="image" src="https://github.com/user-attachments/assets/a6df4ce8-1bc3-4006-a9ff-5debec0b4b13" />
