### PR TITLE
Add folder enumeration signature for ransomware detection

### DIFF
--- a/modules/signatures/windows/discovery_filesystem.py
+++ b/modules/signatures/windows/discovery_filesystem.py
@@ -29,7 +29,7 @@ class FolderEnumeration(Signature):
 
     def run(self):
         targeted_folders = set()
-        pattern = r".*(Users|Documents|Desktop|Downloads|Music|Videos|Pictures|AppData).*\\\*.*"      
+        pattern = r"(?i).*?(Users|Documents|Desktop|Downloads|Music|Videos|Pictures|AppData).*\\\*.*"   
         matches = self.check_file(pattern=pattern, regex=True, all=True)
         
         if matches:


### PR DESCRIPTION
Implements a signature for folder enumeration, targeting user directories that are commonly accessed by ransomware or wipers.

LockBit
<img width="1277" height="1044" alt="image" src="https://github.com/user-attachments/assets/d202123f-dc02-4f87-9685-dc8148cdb0b7" />

ZOVWiper
<img width="1202" height="1181" alt="image" src="https://github.com/user-attachments/assets/39fa63cb-e3af-4c01-90f6-be460ce5e815" />

DynoWiper
<img width="1294" height="1183" alt="image" src="https://github.com/user-attachments/assets/30f3cf2d-e9f6-4920-b19a-1e244799c9c7" />

