### PR TITLE
Add ReadFileRawDiskAccess and modify bootkit sigs

### DIFF
--- a/modules/signatures/windows/bootkit.py
+++ b/modules/signatures/windows/bootkit.py
@@ -219,11 +219,11 @@ class PotentialOverWriteMBR(Signature):
 
     def on_call(self, call, process):
         if call["api"] == "NtWriteFile":
-            handle = self.get_raw_argument(call, "HandleName")
+            handle_name = self.get_raw_argument(call, "HandleName")
             writelength = self.get_raw_argument(call, "Length")
 
-            if handle and handle.lower().startswith((r"\device\harddisk", r"\??\physicaldrive")) and writelength == 512:
-                self.data.append({"modified_drive": "%s" % (filepath)})
+            if handle_name and handle_name.lower().startswith((r"\device\harddisk", r"\??\physicaldrive")) and writelength == 512:
+                self.data.append({"modified_drive": "%s" % (handle_name)})
                 self.ret = True
                 if self.pid:
                     self.mark_call()


### PR DESCRIPTION
added sig for reading from harddrive and also modified the writing to drive sigs to use APIs to allow more visibility/analysis on what is being done and also to handle deviceiocontrol potentially writing to it/modifying it via control codes.

HermeticWiper

<img width="2016" height="933" alt="image" src="https://github.com/user-attachments/assets/13280b4a-883a-486b-8186-8436fc2d63a6" />

<img width="1887" height="992" alt="image" src="https://github.com/user-attachments/assets/5a90ba2c-74f0-43bc-9ba6-25b716dcfcf5" />

<img width="2010" height="619" alt="image" src="https://github.com/user-attachments/assets/855725d1-d4f2-43c8-8db3-36ce165af57f" />

