### PR TITLE
Update ransomware_message for improved detection

### DIFF
--- a/modules/signatures/windows/ransomware_message.py
+++ b/modules/signatures/windows/ransomware_message.py
@@ -110,7 +110,7 @@ class RansomwareMessage(Signature):
                 else:
                     filename = str(raw_name).lower()
                 
-                if filename.endswith((".txt", ".html", ".hta", ".rtf")) or "read_me" in filename or "readme" in filename:
+                if filename.endswith((".txt", ".html", ".hta", ".rtf")) or "read_me" in filename or "readme" in filename or "read-me" in filename:
                     filedata = dropped.get("data")
                     
                     if isinstance(filedata, str):


### PR DESCRIPTION
Updated to better handle ransomware messages and also if it is not detected in an NtWriteFile it will check it in the dropped files. This for instance is needed in Lockbit because it writes it a single byte at a time so there is not a single NtWriteFile with all the message.

Lockbit
<img width="2011" height="206" alt="image" src="https://github.com/user-attachments/assets/1aaceb7a-3db0-476b-a5c9-aea88a933156" />
