### PR TITLE
Add KernelCryptoDriverAbuse signature for ransomware detection

### DIFF
--- a/modules/signatures/windows/ransomware_crypto.py
+++ b/modules/signatures/windows/ransomware_crypto.py
@@ -92,11 +92,13 @@ class KernelCryptoDriverAbuse(Signature):
         }
 
     def on_call(self, call, process):
-        pname = process.get("process_name", "").lower()
-        if pname in self.ignore_procs:
-            return None      
-
         pid = process.get("process_id")
+        if not pid:
+            return None
+
+        pname = process.get("process_name", "").lower()
+        if not pname or pname in self.ignore_procs:
+            return None
 
         if pid not in self.ksec_handles:
             self.ksec_handles[pid] = set()


### PR DESCRIPTION
This detects a process that is using the KsecDD to mass encrypt data (likely ransomware encrypting files). It also limits the marked calls to 20.

Lockbit
<img width="1994" height="1055" alt="image" src="https://github.com/user-attachments/assets/73334f20-9b6c-443a-84a8-f3ee01dfb574" />
