### PR TITLE
Add ransomware detection signatures for file access

### DIFF
--- a/modules/signatures/windows/ransomware_fileaccess.py
+++ b/modules/signatures/windows/ransomware_fileaccess.py
@@ -86,7 +86,6 @@ class MassFileModificationAccess(Signature):
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.targeted_files = set()
-        self.example_file = None
         self.dangerous_strings = ("WRITE", "DELETE", "MAXIMUM_ALLOWED", "GENERIC_ALL")
 
     def on_call(self, call, process):


### PR DESCRIPTION
This file implements two signatures for detecting ransomware behavior: one for stripping file attributes and another for mass file modification access. call marks are limited in number to avoid huge amounts of events but provides a total count.

<img width="2015" height="1048" alt="image" src="https://github.com/user-attachments/assets/1b60522d-6ce7-4ab2-b851-a6a55c6db897" />

<img width="2012" height="1027" alt="image" src="https://github.com/user-attachments/assets/af13e909-30a9-4a02-8a6e-4b380123bfa0" />
