### PR TITLE
Create bypass_edr_syscalls.py for direct syscalls evasion

### DIFF
--- a/modules/signatures/windows/bypass_edr_syscalls.py
+++ b/modules/signatures/windows/bypass_edr_syscalls.py
@@ -45,7 +45,11 @@ class DirectSyscallEvasion(Signature):
             # 32-bit: > 0x70000000 | 64-bit: > 0x7FF000000000
             # If the literal Return Address is in low memory, the malware is 
             # manually executing the syscall (Direct) and the return address will point back to the malware.
-            is_evasive = (0 < caller_addr < 0x70000000) or (0x0000000100000000 <= caller_addr < 0x0000700000000000)
+            is_evasive = False
+            if 0 < addr_val < 0x70000000:
+                is_evasive = True
+            elif 0x0000000100000000 <= addr_val < 0x0000700000000000:
+                is_evasive = True
 
             module = self.get_argument(call, "Module")
             if module:


### PR DESCRIPTION
Added a new Python file for syscall evasion detection logic (the sig name has been updated as only direct syscalls now), I don't think indirect is possible to cover except maybe the volatility module for them.

Pikabot
<img width="1817" height="851" alt="image" src="https://github.com/user-attachments/assets/3ffcc801-11bc-4359-b265-aa7eadf75183" />
