### PR TITLE
Add MalformedDllLoading signature for DLL checks

### DIFF
--- a/modules/signatures/windows/dynamic_function_loading.py
+++ b/modules/signatures/windows/dynamic_function_loading.py
@@ -79,7 +79,7 @@ class MalformedDllLoading(Signature):
             
         # Check if the filename contains massive amounts of raw hex escapes (\x).
         # This occurs when CAPE dumps unprintable bytes that the malware accidentally passed.
-        hex_escape_count = len(re.findall(r"\\x[0-9a-fA-F]{2,4}", filename))
+        hex_escape_count = len(re.findall(r"\\x[0-9a-fA-F]{2}", filename))
         
         # Check if they accidentally passed known API strings to a DLL loader
         api_strings = ["Rtl", "NtQuery", "GetSystem", "MachinePreferred", "Filemark"]


### PR DESCRIPTION
Added a new signature class for detecting malformed DLL loading attempts, including checks for hex escapes and API strings in filenames.

Aside from cleaning it up I can't take credit as Gemini noticed it on a last past of malicious stuff in Pikabot (SHA256 ca5fb5814ec62c8f04936740aabe2664b3c7d036203afbd8425cd67cf1f4b79d) run and suggested it

<img width="1776" height="406" alt="image" src="https://github.com/user-attachments/assets/069df48d-0cff-4fda-99db-c50b718d4cd5" />
