### PR TITLE
Reduce severity and confidence levels in mountpoints

### DIFF
--- a/modules/signatures/windows/discovery_mountpoints.py
+++ b/modules/signatures/windows/discovery_mountpoints.py
@@ -19,7 +19,7 @@ from lib.cuckoo.common.abstracts import Signature
 class DiscoverRegistryMountPoints(Signature):
     name = "discover_registry_mount_points"
     description = "Queries registry mount points to identify historical or connected removable/network drives"
-    severity = 1
+    severity = 2
     confidence = 20
     categories = ["discovery", "ransomware", "wiper"]
     authors = ["Kevin Ross"]
@@ -51,7 +51,7 @@ class DiscoverRegistryMountPoints(Signature):
 class MountPointsVolumeDiscovery(Signature):
     name = "mountpoints_volume_discovery"
     description = "Queries the mount points and then resolves volume paths to enumerate storage devices"
-    severity = 1
+    severity = 2
     confidence = 20
     categories = ["discovery", "ransomware", "wiper"]
     authors = ["Kevin Ross"]


### PR DESCRIPTION
Seems this alerts more than I anticipated in samples. I didn't overly see it outside bootkits and ransomware in testing against others but I was focused on specific samples. 

Until signature can be tightened or false positives/true positives confirmed dropping it to an info as still useful.