### PR TITLE
Add EtherHiding smart contract call detection

### DIFF
--- a/modules/signatures/windows/network_c2_etherhiding.py
+++ b/modules/signatures/windows/network_c2_etherhiding.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2026 Kevin Ross, created with assistance from Gemini
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class EtherHidingSmartContractCall(Signature):
+    name = "etherhiding_smart_contract_call"
+    description = "Transmitted an Ethereum JSON-RPC command over the network, indicative of retrieving a payload/C2 from a smart contract using EtherHiding"
+    severity = 3
+    confidence = 100
+    categories = ["network", "c2", "defense_evasion"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+    ttps = ["T1102", "T1568"]
+
+    filter_apinames = {
+        "HttpSendRequestA", "HttpSendRequestW", 
+        "WinHttpSendRequest", "WinHttpWriteData", 
+        "InternetWriteFile", "send", "WSASend", "sendto"
+    }
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ret = False
+        self.contract_calls = set()
+
+    def on_call(self, call, process):
+        api = call["api"]
+        
+        # Dynamically grab the payload regardless of which networking API was used
+        buffer_data = (
+            self.get_argument(call, "PostData") or 
+            self.get_argument(call, "Buffer") or 
+            self.get_argument(call, "lpBuffer") or 
+            self.get_argument(call, "Optional") or 
+            self.get_argument(call, "lpOptional")
+        )
+
+        if buffer_data and isinstance(buffer_data, str):
+            buffer_lower = buffer_data.lower()
+            
+            # Look for the JSON-RPC payload format
+            if '"jsonrpc"' in buffer_lower and '"method"' in buffer_lower:
+                if '"eth_call"' in buffer_lower or '"eth_gettransactionbyhash"' in buffer_lower or '"eth_getstorageat"' in buffer_lower:
+                    proc_name = process.get("process_name", "unknown")
+                    
+                    # Truncate buffer to prevent massive strings blowing up the UI
+                    event_msg = f"{proc_name} transmitted a smart contract query via {api}: {buffer_data[:150]}..."
+                    
+                    if event_msg not in self.contract_calls:
+                        self.contract_calls.add(event_msg)
+                        self.mark_call()
+                        self.ret = True
+
+    def on_complete(self):
+        if self.ret:
+            self.data.append({"etherhiding_contract_queries": list(self.contract_calls)})
+        return self.ret

--- a/modules/signatures/windows/network_c2_etherhiding.py
+++ b/modules/signatures/windows/network_c2_etherhiding.py
@@ -29,7 +29,7 @@ class EtherHidingSmartContractCall(Signature):
     filter_apinames = {
         "HttpSendRequestA", "HttpSendRequestW", 
         "WinHttpSendRequest", "WinHttpWriteData", 
-        "InternetWriteFile", "send", "WSASend", "sendto"
+        "InternetWriteFile", "send", "WSASend", "sendto", "WSASendTo"
     }
 
     def __init__(self, *args, **kwargs):
@@ -42,11 +42,11 @@ class EtherHidingSmartContractCall(Signature):
         
         # Dynamically grab the payload regardless of which networking API was used
         buffer_data = (
-            self.get_argument(call, "PostData") or 
-            self.get_argument(call, "Buffer") or 
+            self.get_argument(call, "buffer") or 
             self.get_argument(call, "lpBuffer") or 
-            self.get_argument(call, "Optional") or 
-            self.get_argument(call, "lpOptional")
+            self.get_argument(call, "lpOptional") or 
+            self.get_argument(call, "Buffer") or 
+            self.get_argument(call, "PostData")
         )
 
         if buffer_data and isinstance(buffer_data, str):


### PR DESCRIPTION
This signature detects Ethereum JSON-RPC commands indicative of EtherHiding payload retrieval. (https://cloud.google.com/blog/topics/threat-intelligence/unc5142-etherhiding-distribute-malware, 

Sample 113a05106b85844a4fcc943e5b06af75bb45c22cec1e6aa30400a13e00dcfc22
<img width="1945" height="786" alt="image" src="https://github.com/user-attachments/assets/b34dc4b2-3e56-49a6-bf56-49d42e770ed2" />

On this sample it actually comes from unbacked memory
<img width="1977" height="1052" alt="image" src="https://github.com/user-attachments/assets/154e89b0-8f4f-4924-97e3-da3909356554" />
