### PR TITLE
Add signatures for exception-driven execution detection

### DIFF
--- a/modules/signatures/windows/exception_execution.py
+++ b/modules/signatures/windows/exception_execution.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class ExceptionDrivenExecution(Signature):
     name = "exception_driven_execution"
-    description = "The malware registered a Vectored Exception Handler (VEH) and intentionally triggered exceptions or manipulated thread contexts. May be used to hijack the OS error dispatcher to execute a payload or shellcode"
+    description = "Registered a Vectored Exception Handler (VEH) and intentionally triggered exceptions or manipulated thread contexts. May be used to hijack the OS error dispatcher to execute a payload or shellcode"
     severity = 3
     confidence = 50
     categories = ["evasion", "anti_debugging", "stealth", "obfuscation"]

--- a/modules/signatures/windows/exception_execution.py
+++ b/modules/signatures/windows/exception_execution.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2026 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ExceptionDrivenExecution(Signature):
+    name = "exception_driven_execution"
+    description = "The malware registered a Vectored Exception Handler (VEH) and intentionally triggered exceptions or manipulated thread contexts. May be used to hijack the OS error dispatcher to execute a payload or shellcode"
+    severity = 3
+    confidence = 50
+    categories = ["evasion", "anti_debugging", "stealth", "obfuscation"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+    ttps = ["T1055", "T1622"]
+
+    filter_apinames = {
+        # VEH Registration
+        "RtlAddVectoredExceptionHandler", 
+        # Context Manipulation (Post-Crash recovery/redirection)
+        "NtGetContextThread", "GetThreadContext",
+        "NtSetContextThread", "SetThreadContext",
+        # Explicit Exception Triggers
+        "RaiseException", "RtlRaiseException",
+        "DebugBreak", "DbgBreakPoint"
+    }
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ret = False
+        self.veh_pids = set()
+        self.evasion_events = set()
+
+    def on_call(self, call, process):
+        api = call["api"]
+        pid = process.get("process_id", "unknown")
+        proc_name = process.get("process_name", "unknown")
+
+        if api == "RtlAddVectoredExceptionHandler":
+            self.veh_pids.add(pid)
+
+        elif api in ("RaiseException", "RtlRaiseException", "DebugBreak", "DbgBreakPoint"):
+            # If a process registers a VEH and then explicitly raises an exception or debug break, 
+            # it is manually passing execution flow to its own handler.
+            if pid in self.veh_pids:
+                
+                trigger_type = "a Software Breakpoint" if "Break" in api else "an explicit Exception"
+                event_msg = f"Process '{proc_name}' (PID: {pid}) registered a VEH and then triggered {trigger_type} via {api}. Indicative of Exception-Driven Execution."
+                
+                if event_msg not in self.evasion_events:
+                    self.evasion_events.add(event_msg)
+                    self.mark_call()
+                    self.ret = True
+
+        elif api in ("NtGetContextThread", "GetThreadContext", "NtSetContextThread", "SetThreadContext"):
+            # If the malware used a native CPU fault (like Divide-by-Zero, UD2, or PAGE_NOACCESS), 
+            # we won't see the trigger API, but we WILL see it trying to recover the thread context here.
+            if pid in self.veh_pids:
+                event_msg = f"Process '{proc_name}' (PID: {pid}) registered a VEH and used {api} to inspect/modify CPU registers to redirect execution flow."
+                
+                if event_msg not in self.evasion_events:
+                    self.evasion_events.add(event_msg)
+                    self.mark_call()
+                    self.ret = True
+
+    def on_complete(self):
+        if self.ret:
+            self.data.append({"exception_hijacking_events": list(self.evasion_events)})
+        return self.ret
+      
+
+class AllocatedMemoryProtectionNoAccess(Signature):
+    name = "allocated_memory_protection_noaccess"
+    description = "Allocated memory and changed its protection to PAGE_NOACCESS, may be used to hide payloads from memory scanners or to trigger an access violation for exception-driven execution"
+    severity = 2
+    confidence = 100
+    categories = ["evasion", "stealth", "defense_evasion", "obfuscation"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+    ttps = ["T1027", "T1055"]
+
+    filter_apinames = {
+        # Allocations
+        "NtAllocateVirtualMemory", "VirtualAlloc", "VirtualAllocEx",
+        # Protections
+        "NtProtectVirtualMemory", "VirtualProtect", "VirtualProtectEx"
+    }
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ret = False
+        
+        # Track dynamically allocated memory ranges per PID
+        self.allocated_memory = {}
+        self.locked_payload_events = set()
+
+    def on_call(self, call, process):
+        api = call["api"]
+        pid = process.get("process_id", "unknown")
+        proc_name = process.get("process_name", "unknown")
+
+        if pid not in self.allocated_memory:
+            self.allocated_memory[pid] = []
+
+        if api in ("NtAllocateVirtualMemory", "VirtualAlloc", "VirtualAllocEx"):
+            base = self.get_argument(call, "BaseAddress") or self.get_argument(call, "lpAddress")
+            size = self.get_argument(call, "RegionSize") or self.get_argument(call, "dwSize")
+            
+            if base and size:
+                try:
+                    base_val = int(base, 16) if isinstance(base, str) else int(base)
+                    size_val = int(size, 16) if isinstance(size, str) else int(size)
+                    
+                    self.allocated_memory[pid].append({
+                        "base": base_val,
+                        "end": base_val + size_val
+                    })
+                except (ValueError, TypeError):
+                    pass
+
+        elif api in ("NtProtectVirtualMemory", "VirtualProtect", "VirtualProtectEx"):
+            protection = self.get_argument(call, "NewAccessProtection") or self.get_argument(call, "flNewProtect")
+            base_address = self.get_argument(call, "BaseAddress") or self.get_argument(call, "lpAddress")
+            
+            if protection and base_address:
+                try:
+                    prot_val = int(protection, 16) if isinstance(protection, str) else int(protection)
+                    base_val = int(base_address, 16) if isinstance(base_address, str) else int(base_address)
+                    
+                    # 0x01 is the Windows constant for PAGE_NOACCESS
+                    if prot_val == 0x01:
+                        is_payload = False
+                        for mem_range in self.allocated_memory[pid]:
+                            if mem_range["base"] <= base_val <= mem_range["end"]:
+                                is_payload = True
+                                break
+                                
+                        if is_payload:
+                            event_msg = f"Process '{proc_name}' (PID: {pid}) locked dynamically allocated memory at 0x{base_val:x} with PAGE_NOACCESS."
+                            if event_msg not in self.locked_payload_events:
+                                self.locked_payload_events.add(event_msg)
+                                self.mark_call()
+                                self.ret = True
+                                
+                except (ValueError, TypeError):
+                    pass
+
+    def on_complete(self):
+        if self.ret:
+            self.data.append({"payload_locking_events": list(self.locked_payload_events)})
+        return self.ret

--- a/modules/signatures/windows/exception_execution.py
+++ b/modules/signatures/windows/exception_execution.py
@@ -28,7 +28,7 @@ class ExceptionDrivenExecution(Signature):
 
     filter_apinames = {
         # VEH Registration
-        "RtlAddVectoredExceptionHandler", 
+        "RtlAddVectoredExceptionHandler", "AddVectoredExceptionHandler",
         # Context Manipulation (Post-Crash recovery/redirection)
         "NtGetContextThread", "GetThreadContext",
         "NtSetContextThread", "SetThreadContext",
@@ -48,7 +48,7 @@ class ExceptionDrivenExecution(Signature):
         pid = process.get("process_id", "unknown")
         proc_name = process.get("process_name", "unknown")
 
-        if api == "RtlAddVectoredExceptionHandler":
+        if api in ("RtlAddVectoredExceptionHandler", "AddVectoredExceptionHandler"):
             self.veh_pids.add(pid)
 
         elif api in ("RaiseException", "RtlRaiseException", "DebugBreak", "DbgBreakPoint"):
@@ -116,18 +116,19 @@ class AllocatedMemoryProtectionNoAccess(Signature):
             self.allocated_memory[pid] = []
 
         if api in ("NtAllocateVirtualMemory", "VirtualAlloc", "VirtualAllocEx"):
-            base = self.get_argument(call, "BaseAddress") or self.get_argument(call, "lpAddress")
+            base = self.get_argument(call, "BaseAddress") if api == "NtAllocateVirtualMemory" else call.get("retval")
             size = self.get_argument(call, "RegionSize") or self.get_argument(call, "dwSize")
             
             if base and size:
                 try:
-                    base_val = int(base, 16) if isinstance(base, str) else int(base)
-                    size_val = int(size, 16) if isinstance(size, str) else int(size)
+                    base_val = int(base, 0) if isinstance(base, str) else int(base)
+                    size_val = int(size, 0) if isinstance(size, str) else int(size)
                     
-                    self.allocated_memory[pid].append({
-                        "base": base_val,
-                        "end": base_val + size_val
-                    })
+                    if base_val:
+                        self.allocated_memory[pid].append({
+                            "base": base_val,
+                            "end": base_val + size_val
+                        })
                 except (ValueError, TypeError):
                     pass
 
@@ -137,8 +138,8 @@ class AllocatedMemoryProtectionNoAccess(Signature):
             
             if protection and base_address:
                 try:
-                    prot_val = int(protection, 16) if isinstance(protection, str) else int(protection)
-                    base_val = int(base_address, 16) if isinstance(base_address, str) else int(base_address)
+                    prot_val = int(protection, 0) if isinstance(protection, str) else int(protection)
+                    base_val = int(base_address, 0) if isinstance(base_address, str) else int(base_address)
                     
                     # 0x01 is the Windows constant for PAGE_NOACCESS
                     if prot_val == 0x01:


### PR DESCRIPTION
This file implements two signatures for detecting exception-driven execution and memory protection manipulation in malware. The first signature identifies processes that register a Vectored Exception Handler and trigger exceptions, while the second monitors memory allocations and protection changes to detect potential payload hiding.

Sample (infostealer doing this and using indirect syscalls  that cause cape to lose tracking of it) bcff5812c1bdd518470f91a0b2e5c1e8ed28ba96c58e28953c1e5d9b6cfe9db0

<img width="2089" height="680" alt="image" src="https://github.com/user-attachments/assets/e53e80d0-9c82-4a17-a7cb-677b07e7b977" />
